### PR TITLE
MinFeeAmount support

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/MultipartyTransactionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/MultipartyTransactionTests.cs
@@ -5,6 +5,7 @@ using WalletWasabi.Crypto;
 using WalletWasabi.Extensions;
 using WalletWasabi.Helpers;
 using WalletWasabi.Tests.Helpers;
+using WalletWasabi.WabiSabi.Backend;
 using WalletWasabi.WabiSabi.Backend.Models;
 using WalletWasabi.WabiSabi.Backend.Rounds;
 using WalletWasabi.WabiSabi.Models;
@@ -180,6 +181,7 @@ public class MultipartyTransactionTests
 		// Witness can only be accepted once per input
 		ThrowsProtocolException(WabiSabiProtocolErrorCode.WitnessAlreadyProvided, () => alice1Sig.AddWitness(alice1SignedInput.Index, alice1SignedInput.Input.WitScript));
 	}
+
 	[Fact]
 	public void PublishWitnessesTest()
 	{
@@ -457,7 +459,10 @@ public class MultipartyTransactionTests
 		var round = WabiSabiFactory.CreateRound(parameters);
 
 		// Make sure the highest fee rate is low, so coordinator script will be added.
-		var coinjoinWithCoordinatorScript = Arena.AddCoordinationFee(round, coinjoin, coordinatorScript);
+		WabiSabiConfig cfg = new();
+		using Arena arena = ArenaBuilder.From(cfg).Create([round]);
+
+		var coinjoinWithCoordinatorScript = arena.AddCoordinationFee(round, coinjoin, coordinatorScript);
 		coinjoinWithCoordinatorScript.Finalize();
 		Assert.NotSame(coinjoinWithCoordinatorScript, coinjoin);
 	}

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -664,7 +664,7 @@ public partial class Arena : PeriodicRunner
 		}
 	}
 
-	public static ConstructionState AddCoordinationFee(Round round, ConstructionState coinjoin, Script coordinatorScriptPubKey)
+	public ConstructionState AddCoordinationFee(Round round, ConstructionState coinjoin, Script coordinatorScriptPubKey)
 	{
 		var sizeToPayFor = coinjoin.EstimatedVsize + coordinatorScriptPubKey.EstimateOutputVsize();
 		var miningFee = round.Parameters.MiningFeeRate.GetFee(sizeToPayFor) + Money.Satoshis(1);
@@ -674,9 +674,9 @@ public partial class Arena : PeriodicRunner
 
 		round.LogInfo($"Expected coordination fee: {expectedCoordinationFee} - Available coordination: {availableCoordinationFee}.");
 
-		if (availableCoordinationFee > round.Parameters.AllowedOutputAmounts.Min)
+		if (availableCoordinationFee >= Config.MinFeeAmount)
 		{
-			coinjoin = coinjoin.AddOutput(new TxOut(availableCoordinationFee, coordinatorScriptPubKey))
+			coinjoin = coinjoin.AddFeeOutput(new TxOut(availableCoordinationFee, coordinatorScriptPubKey))
 				.AsPayingForSharedOverhead();
 		}
 		else

--- a/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
+++ b/WalletWasabi/WabiSabi/Backend/WabiSabiConfig.cs
@@ -76,6 +76,11 @@ public class WabiSabiConfig : ConfigBase
 	[JsonConverter(typeof(MoneyBtcJsonConverter))]
 	public Money MaxRegistrableAmount { get; set; } = Money.Coins(43_000m);
 
+	[DefaultValueMoneyBtc("0.00001")]
+	[JsonProperty(PropertyName = "MinFeeAmount", DefaultValueHandling = DefaultValueHandling.Populate)]
+	[JsonConverter(typeof(MoneyBtcJsonConverter))]
+	public Money MinFeeAmount { get; set; } = Money.Coins(0.00001m);
+
 	[DefaultValue(true)]
 	[JsonProperty(PropertyName = "AllowNotedInputRegistration", DefaultValueHandling = DefaultValueHandling.Populate)]
 	public bool AllowNotedInputRegistration { get; set; } = true;

--- a/WalletWasabi/WabiSabi/Models/MultipartyTransaction/ConstructionState.cs
+++ b/WalletWasabi/WabiSabi/Models/MultipartyTransaction/ConstructionState.cs
@@ -98,6 +98,26 @@ public record ConstructionState : MultipartyTransactionState
 		return this with { Events = Events.Add(new OutputAdded(output)) };
 	}
 
+	public ConstructionState AddFeeOutput(TxOut output)
+	{
+		if (output.IsDust())
+		{
+			throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.DustOutput);
+		}
+
+		if (!StandardScripts.IsStandardScriptPubKey(output.ScriptPubKey))
+		{
+			throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.NonStandardOutput);
+		}
+
+		if (!Parameters.AllowedOutputTypes.Any(x => output.ScriptPubKey.IsScriptType(x)))
+		{
+			throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.ScriptNotAllowed);
+		}
+
+		return this with { Events = Events.Add(new OutputAdded(output)) };
+	}
+
 	public SigningState Finalize()
 	{
 		if (EstimatedVsize > Parameters.MaxTransactionSize)


### PR DESCRIPTION
MinFeeAmount support, separated from round.Parameters.AllowedOutputAmounts.Min

The goal is to not to drop even a relatively small fee so easily to the miners.
The default value is 1000 sat.