### PR TITLE
Fix crash when CoinList is Rebuilt

### DIFF
--- a/WalletWasabi.Fluent/Extensions/ObservableExtensions.cs
+++ b/WalletWasabi.Fluent/Extensions/ObservableExtensions.cs
@@ -116,4 +116,26 @@ public static class ObservableExtensions
 					 .DisposeMany()
 					 .AsObservableCache();
 	}
+
+	public static (IObservableCache<TObject1, TKey1>, IObservableCache<TObject2, TKey2>) Fetch<TObject1, TKey1, TObject2, TKey2>(
+		this IObservable<Unit> signal,
+		(Func<IEnumerable<TObject1>> Source, Func<TObject1, TKey1> KeySelector, IEqualityComparer<TObject1>? EqualityComparer) first,
+		(Func<IEnumerable<TObject2>> Source, Func<TObject2, TKey2> KeySelector, IEqualityComparer<TObject2>? EqualityComparer) second)
+		where TKey1 : notnull
+		where TKey2 : notnull
+		where TObject1 : notnull
+		where TObject2 : notnull
+	{
+		var cache1 = signal.Select(_ => first.Source())
+			.EditDiff(first.KeySelector, first.EqualityComparer)
+			.DisposeMany()
+			.AsObservableCache();
+
+		var cache2 = signal.Select(_ => second.Source())
+			.EditDiff(second.KeySelector, second.EqualityComparer)
+			.DisposeMany()
+			.AsObservableCache();
+
+		return (cache1, cache2);
+	}
 }

--- a/WalletWasabi.Fluent/Models/Wallets/UserSelectionCoinListModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/UserSelectionCoinListModel.cs
@@ -9,9 +9,9 @@ namespace WalletWasabi.Fluent.Models.Wallets;
 [AutoInterface]
 public partial class UserSelectionCoinListModel(Wallet wallet, IWalletModel walletModel, SmartCoin[] selectedCoins) : CoinListModel(wallet, walletModel)
 {
-	protected override ICoinModel[] GetCoins()
+	protected override ICoinModel[] CreateCoinModels()
 	{
-		return selectedCoins.Select(GetCoinModel).ToArray();
+		return selectedCoins.Select(CreateCoinModel).ToArray();
 	}
 
 	protected override Pocket[] GetPockets()

--- a/WalletWasabi.Fluent/Models/Wallets/WalletCoinsModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletCoinsModel.cs
@@ -41,8 +41,8 @@ public partial class WalletCoinsModel(Wallet wallet, IWalletModel walletModel) :
 		return Wallet.GetPockets().ToArray();
 	}
 
-	protected override ICoinModel[] GetCoins()
+	protected override ICoinModel[] CreateCoinModels()
 	{
-		return Wallet.Coins.Select(GetCoinModel).ToArray();
+		return Wallet.Coins.Select(CreateCoinModel).ToArray();
 	}
 }


### PR DESCRIPTION
Original description is here: https://github.com/WalletWasabi/WalletWasabi/pull/13302

> Superseedes #13269
> 
> It doesn't fix the underlying issue and I'm sure there are 23423 better ways to do it, but still it works perfectly. The problem with the crash is that `GetPockets` is called before `CreateCoinsModel`. This PR creates an overload of `Fetch` to make 2 cache updates atomic and then swaps the calls of `GetPockets` and `CreateCoinsModel` Then I also included #13269 because why not?
> 

