### PR TITLE
Minor renaming and test fixes

### DIFF
--- a/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
+++ b/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
@@ -401,7 +401,7 @@ public static class WabiSabiFactory
 		{
 			MaxInputCountByRound = 2,
 			MinInputCountByRoundMultiplier = 0.5,
-			MaxSuggestedAmountBase = Money.Satoshis(ProtocolConstants.MaxAmountPerAlice),
+			MaxSuggestedAmountBase = Money.Satoshis(ProtocolConstants.MaxAmountCredentialValue),
 			CreateNewRoundBeforeInputRegEnd = TimeSpan.Zero,
 
 			DoSSeverity = Money.Coins(1.0m),

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
@@ -33,7 +33,7 @@ public class StepTransactionSigningTests
 		{
 			MaxInputCountByRound = 2,
 			MinInputCountByRoundMultiplier = 0.5,
-			MaxSuggestedAmountBase = Money.Satoshis(ProtocolConstants.MaxAmountPerAlice),
+			MaxSuggestedAmountBase = Money.Satoshis(ProtocolConstants.MaxAmountCredentialValue),
 			CreateNewRoundBeforeInputRegEnd = TimeSpan.Zero
 		};
 		var (keyChain, coin1, coin2) = WabiSabiFactory.CreateCoinKeyPairs();

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/Rounds/MultipartyTransactionStateTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/Rounds/MultipartyTransactionStateTests.cs
@@ -85,7 +85,7 @@ public class MultipartyTransactionStateTests
 		Round roundLargest = new(parameters, SecureRandom.Instance);
 
 		// First Round is the largest.
-		Assert.Equal(Money.Satoshis(ProtocolConstants.MaxAmountPerAlice), roundLargest.Parameters.MaxSuggestedAmount);
+		Assert.Equal(Money.Satoshis(ProtocolConstants.MaxAmountCredentialValue), roundLargest.Parameters.MaxSuggestedAmount);
 
 		// Simulate 63 successful rounds.
 		Dictionary<Money, int> histogram = new();
@@ -119,12 +119,12 @@ public class MultipartyTransactionStateTests
 		for (int i = 0; i < 2; i++)
 		{
 			maxSuggestedAmountProvider.StepMaxSuggested(roundLargest, false);
-			Assert.Equal(Money.Satoshis(ProtocolConstants.MaxAmountPerAlice), maxSuggestedAmountProvider.MaxSuggestedAmount);
+			Assert.Equal(Money.Satoshis(ProtocolConstants.MaxAmountCredentialValue), maxSuggestedAmountProvider.MaxSuggestedAmount);
 		}
 
 		// Finally one successful round.
 		maxSuggestedAmountProvider.StepMaxSuggested(roundLargest, true);
-		Assert.Equal(Money.Satoshis(ProtocolConstants.MaxAmountPerAlice), maxSuggestedAmountProvider.MaxSuggestedAmount);
+		Assert.Equal(Money.Satoshis(ProtocolConstants.MaxAmountCredentialValue), maxSuggestedAmountProvider.MaxSuggestedAmount);
 
 		maxSuggestedAmountProvider.StepMaxSuggested(roundLargest, true);
 		Assert.Equal(Money.Coins(0.1m), maxSuggestedAmountProvider.MaxSuggestedAmount);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/AmountDecomposerTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/AmountDecomposerTests.cs
@@ -50,7 +50,7 @@ public class AmountDecomposerTests
 		var feePerOutput = feeRate.GetFee(outputVirtualSize);
 		var registeredCoinEffectiveValues = GenerateRandomCoins().Take(3).Select(c => c.EffectiveValue(feeRate, CoordinationFeeRate.Zero)).ToList();
 		var theirCoinEffectiveValues = GenerateRandomCoins().Take(30).Select(c => c.EffectiveValue(feeRate, CoordinationFeeRate.Zero)).ToList();
-		var allowedOutputAmountRange = new MoneyRange(Money.Satoshis(minOutputAmount), Money.Satoshis(ProtocolConstants.MaxAmountPerAlice));
+		var allowedOutputAmountRange = new MoneyRange(Money.Satoshis(minOutputAmount), Money.Satoshis(ProtocolConstants.MaxAmountCredentialValue));
 		var allowedOutputTypes = isTaprootEnabled ? new List<ScriptType>() { ScriptType.Taproot, ScriptType.P2WPKH } : new List<ScriptType>() { ScriptType.P2WPKH };
 
 		var totalEffectiveValue = registeredCoinEffectiveValues.Sum(x => x);
@@ -90,7 +90,7 @@ public class AmountDecomposerTests
 		var script = key.GetScriptPubKey(ScriptPubKeyType.Segwit);
 		while (true)
 		{
-			var amount = Random.GetInt64(100_000, ProtocolConstants.MaxAmountPerAlice);
+			var amount = Random.GetInt64(100_000, ProtocolConstants.MaxAmountCredentialValue);
 			yield return CreateCoin(script, amount);
 		}
 	}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
@@ -108,7 +108,7 @@ public class ArenaClientTests
 		var wabiSabiApi = new WabiSabiController(idempotencyRequestCache, arena, coinJoinFeeRateStatStore, affiliationManager, coinJoinMempoolManager);
 
 		InsecureRandom rnd = InsecureRandom.Instance;
-		var amountClient = new WabiSabiClient(round.AmountCredentialIssuerParameters, rnd, 4300000000000L);
+		var amountClient = new WabiSabiClient(round.AmountCredentialIssuerParameters, rnd, ProtocolConstants.MaxAmountCredentialValue);
 		var vsizeClient = new WabiSabiClient(round.VsizeCredentialIssuerParameters, rnd, 2000L);
 		var apiClient = new ArenaClient(amountClient, vsizeClient, config.CoordinatorIdentifier, wabiSabiApi);
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -151,7 +151,7 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 					ConnectionConfirmationTimeout = TimeSpan.FromSeconds(60),
 					OutputRegistrationTimeout = TimeSpan.FromSeconds(60),
 					TransactionSigningTimeout = TimeSpan.FromSeconds(60),
-					MaxSuggestedAmountBase = Money.Satoshis(ProtocolConstants.MaxAmountPerAlice),
+					MaxSuggestedAmountBase = Money.Satoshis(ProtocolConstants.MaxAmountCredentialValue),
 					CreateNewRoundBeforeInputRegEnd = TimeSpan.Zero
 				});
 
@@ -226,7 +226,7 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 					ConnectionConfirmationTimeout = TimeSpan.FromSeconds(60),
 					OutputRegistrationTimeout = TimeSpan.FromSeconds(60),
 					TransactionSigningTimeout = TimeSpan.FromSeconds(60),
-					MaxSuggestedAmountBase = Money.Satoshis(ProtocolConstants.MaxAmountPerAlice),
+					MaxSuggestedAmountBase = Money.Satoshis(ProtocolConstants.MaxAmountCredentialValue),
 					CreateNewRoundBeforeInputRegEnd = TimeSpan.Zero
 				});
 
@@ -342,7 +342,7 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 				ConnectionConfirmationTimeout = TimeSpan.FromSeconds(60),
 				OutputRegistrationTimeout = TimeSpan.FromSeconds(60),
 				TransactionSigningTimeout = TimeSpan.FromSeconds(5 * inputCount),
-				MaxSuggestedAmountBase = Money.Satoshis(ProtocolConstants.MaxAmountPerAlice),
+				MaxSuggestedAmountBase = Money.Satoshis(ProtocolConstants.MaxAmountCredentialValue),
 				CreateNewRoundBeforeInputRegEnd = TimeSpan.Zero
 			}))).CreateClient();
 
@@ -451,7 +451,7 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 						ConnectionConfirmationTimeout = TimeSpan.FromSeconds(2 * ExpectedInputNumber),
 						OutputRegistrationTimeout = TimeSpan.FromSeconds(5 * ExpectedInputNumber),
 						TransactionSigningTimeout = TimeSpan.FromSeconds(3 * ExpectedInputNumber),
-						MaxSuggestedAmountBase = Money.Satoshis(ProtocolConstants.MaxAmountPerAlice),
+						MaxSuggestedAmountBase = Money.Satoshis(ProtocolConstants.MaxAmountCredentialValue),
 						CreateNewRoundBeforeInputRegEnd = TimeSpan.Zero
 					});
 				}));

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Models/MultipartyTransactionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Models/MultipartyTransactionTests.cs
@@ -5,6 +5,7 @@ using WalletWasabi.Crypto;
 using WalletWasabi.Extensions;
 using WalletWasabi.Helpers;
 using WalletWasabi.Tests.Helpers;
+using WalletWasabi.WabiSabi;
 using WalletWasabi.WabiSabi.Backend;
 using WalletWasabi.WabiSabi.Backend.Models;
 using WalletWasabi.WabiSabi.Backend.Rounds;
@@ -422,7 +423,7 @@ public class MultipartyTransactionTests
 		var parameters = WabiSabiFactory.CreateRoundParameters(new()
 		{
 			MinRegistrableAmount = Money.Zero,
-			MaxRegistrableAmount = Money.Coins(43000m),
+			MaxRegistrableAmount = Money.Satoshis(ProtocolConstants.MaxAmountCredentialValue),
 			MaxSuggestedAmountBase = Money.Coins(Constants.MaximumNumberOfBitcoins)
 		}) with
 		{

--- a/WalletWasabi/Backend/Models/Responses/TwoFactorVerifyResponse.cs
+++ b/WalletWasabi/Backend/Models/Responses/TwoFactorVerifyResponse.cs
@@ -5,4 +5,6 @@ public class TwoFactorVerifyResponse
 	public required string SecretWallet { get; set; }
 
 	public required string ClientServerId { get; set; }
+
+	public required int InvalidLoginCounter { get; set; }
 }

--- a/WalletWasabi/Extensions/DictionaryExtensions.cs
+++ b/WalletWasabi/Extensions/DictionaryExtensions.cs
@@ -15,12 +15,10 @@ public static class DictionaryExtensions
 
 	public static TValue GetOrCreate<TKey, TValue>(this IDictionary<TKey, TValue> dict, TKey key) where TValue : new()
 	{
-		if (dict.ContainsKey(key))
+		if (!dict.TryGetValue(key, out TValue? value))
 		{
-			return dict[key];
+			dict.Add(key, value = new());
 		}
-		TValue value = new();
-		dict.Add(key, value);
 		return value;
 	}
 }

--- a/WalletWasabi/Helpers/Constants.cs
+++ b/WalletWasabi/Helpers/Constants.cs
@@ -46,8 +46,6 @@ public static class Constants
 
 	public const decimal MaximumNumberOfBitcoins = 20999999.9769m;
 
-	public const long MaximumSupportedAmount = 4300000000000L;
-
 	public const int SemiPrivateThreshold = 2;
 
 	public const int FastestConfirmationTarget = 1;

--- a/WalletWasabi/WabiSabi/Backend/DoSPrevention/Prison.cs
+++ b/WalletWasabi/WabiSabi/Backend/DoSPrevention/Prison.cs
@@ -80,7 +80,8 @@ public class Prison
 
 			var maxOffense = offenderHistory.Count == 0
 				? 1
-				: offenderHistory.Max( x => x switch {
+				: offenderHistory.Max(x => x switch
+				{
 					{ Method: RoundDisruptionMethod.DidNotConfirm } => configuration.PenaltyFactorForDisruptingConfirmation,
 					{ Method: RoundDisruptionMethod.DidNotSign } => configuration.PenaltyFactorForDisruptingSigning,
 					{ Method: RoundDisruptionMethod.DoubleSpent } => configuration.PenaltyFactorForDisruptingByDoubleSpending,
@@ -157,5 +158,10 @@ public class Prison
 		{
 			Logger.LogWarning($"Failed to persist offender '{offender.OutPoint}'.");
 		}
+	}
+
+	public int GetCount()
+	{
+		return OffendersByTxId.Count;
 	}
 }

--- a/WalletWasabi/WabiSabi/Backend/Rounds/BlameRound.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/BlameRound.cs
@@ -7,11 +7,10 @@ namespace WalletWasabi.WabiSabi.Backend.Rounds;
 public class BlameRound : Round
 {
 	public BlameRound(RoundParameters parameters, Round blameOf, ISet<OutPoint> blameWhitelist, WasabiRandom random)
-		: base(parameters, random)
+		: base(parameters, random, parameters.BlameInputRegistrationTimeout)
 	{
 		BlameOf = blameOf;
 		BlameWhitelist = blameWhitelist;
-		InputRegistrationTimeFrame = TimeFrame.Create(Parameters.BlameInputRegistrationTimeout).StartNow();
 	}
 
 	public Round BlameOf { get; }

--- a/WalletWasabi/WabiSabi/Backend/Rounds/MaxSuggestedAmountProvider.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/MaxSuggestedAmountProvider.cs
@@ -17,7 +17,7 @@ public class MaxSuggestedAmountProvider
 	private WabiSabiConfig Config { get; init; }
 	private int Counter { get; set; }
 	public Money MaxSuggestedAmount { get; private set; }
-	public Money AbsoluteMaximumInput { get; } = Money.Satoshis(ProtocolConstants.MaxAmountPerAlice);
+	public Money AbsoluteMaximumInput { get; } = Money.Satoshis(ProtocolConstants.MaxAmountCredentialValue);
 
 	private void CheckOrGenerateRoundCounterDividerAndMaxAmounts()
 	{

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Round.cs
@@ -31,7 +31,7 @@ public enum EndRoundState
 
 public class Round
 {
-	public Round(RoundParameters parameters, WasabiRandom random)
+	public Round(RoundParameters parameters, WasabiRandom random, TimeSpan? inputRegistrationTimeout = null)
 	{
 		Parameters = parameters;
 
@@ -42,7 +42,7 @@ public class Round
 		AmountCredentialIssuerParameters = AmountCredentialIssuer.CredentialIssuerSecretKey.ComputeCredentialIssuerParameters();
 		VsizeCredentialIssuerParameters = VsizeCredentialIssuer.CredentialIssuerSecretKey.ComputeCredentialIssuerParameters();
 
-		InputRegistrationTimeFrame = TimeFrame.Create(Parameters.StandardInputRegistrationTimeout).StartNow();
+		InputRegistrationTimeFrame = TimeFrame.Create(inputRegistrationTimeout ?? Parameters.StandardInputRegistrationTimeout).StartNow();
 		ConnectionConfirmationTimeFrame = TimeFrame.Create(Parameters.ConnectionConfirmationTimeout);
 		OutputRegistrationTimeFrame = TimeFrame.Create(Parameters.OutputRegistrationTimeout);
 		TransactionSigningTimeFrame = TimeFrame.Create(Parameters.TransactionSigningTimeout);
@@ -165,7 +165,6 @@ public class Round
 				Parameters.AllowedOutputTypes,
 				Parameters.Network,
 				Parameters.MiningFeeRate.FeePerK,
-				Parameters.CoordinationFeeRate,
 				Parameters.MaxTransactionSize,
 				Parameters.MinRelayTxFee.FeePerK,
 				Parameters.MaxAmountCredentialValue,

--- a/WalletWasabi/WabiSabi/Backend/Rounds/RoundParameters.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/RoundParameters.cs
@@ -70,7 +70,7 @@ public record RoundParameters
 	public TimeSpan BlameInputRegistrationTimeout { get; init; }
 
 	public Money MinAmountCredentialValue => AllowedInputAmounts.Min;
-	public Money MaxAmountCredentialValue => Constants.MaximumSupportedAmount;
+	public Money MaxAmountCredentialValue => ProtocolConstants.MaxAmountCredentialValue;
 
 	public int InitialInputVsizeAllocation { get; init; }
 	public int MaxVsizeCredentialValue { get; init; }

--- a/WalletWasabi/WabiSabi/Client/CredentialDependencies/DependencyGraph.cs
+++ b/WalletWasabi/WabiSabi/Client/CredentialDependencies/DependencyGraph.cs
@@ -27,7 +27,7 @@ public record DependencyGraph
 
 	// Internal properties used to keep track of effective values and edges
 	public ImmutableSortedDictionary<CredentialType, CredentialEdgeSet> EdgeSets { get; init; } = ImmutableSortedDictionary<CredentialType, CredentialEdgeSet>.Empty
-		.Add(CredentialType.Amount, new() { CredentialType = CredentialType.Amount, MaxCredentialValue = ProtocolConstants.MaxAmountPerAlice })
+		.Add(CredentialType.Amount, new() { CredentialType = CredentialType.Amount, MaxCredentialValue = ProtocolConstants.MaxAmountCredentialValue })
 		.Add(CredentialType.Vsize, new() { CredentialType = CredentialType.Vsize, MaxCredentialValue = ProtocolConstants.MaxVsizeCredentialValue });
 
 	public long Balance(RequestNode node, CredentialType credentialType) => EdgeSets[credentialType].Balance(node);

--- a/WalletWasabi/WabiSabi/Crypto/RoundHasher.cs
+++ b/WalletWasabi/WabiSabi/Crypto/RoundHasher.cs
@@ -21,7 +21,6 @@ public static class RoundHasher
 			ImmutableSortedSet<ScriptType> allowedOutputTypes,
 			Network network,
 			long feePerK,
-			CoordinationFeeRate coordinationFeeRate,
 			int maxTransactionSize,
 			long minRelayTxFeePerK,
 			long maxAmountCredentialValue,
@@ -44,7 +43,7 @@ public static class RoundHasher
 			.Append(ProtocolConstants.RoundAllowedOutputTypesStrobeLabel, allowedOutputTypes)
 			.Append(ProtocolConstants.RoundNetworkStrobeLabel, network.ToString())
 			.Append(ProtocolConstants.RoundFeeRateStrobeLabel, feePerK)
-			.Append(ProtocolConstants.RoundCoordinationFeeRateStrobeLabel, coordinationFeeRate)
+			.Append(ProtocolConstants.RoundCoordinationFeeRateStrobeLabel, CoordinationFeeRate.Zero)
 			.Append(ProtocolConstants.RoundMaxTransactionSizeStrobeLabel, maxTransactionSize)
 			.Append(ProtocolConstants.RoundMinRelayTxFeeStrobeLabel, minRelayTxFeePerK)
 			.Append(ProtocolConstants.RoundMaxAmountCredentialValueStrobeLabel, maxAmountCredentialValue)

--- a/WalletWasabi/WabiSabi/Models/RoundState.cs
+++ b/WalletWasabi/WabiSabi/Models/RoundState.cs
@@ -55,7 +55,7 @@ public record RoundState(uint256 Id,
 		};
 
 	public WabiSabiClient CreateAmountCredentialClient(WasabiRandom random) =>
-		new(AmountCredentialIssuerParameters, random, Constants.MaximumSupportedAmount);
+		new(AmountCredentialIssuerParameters, random, ProtocolConstants.MaxAmountCredentialValue);
 
 	public WabiSabiClient CreateVsizeCredentialClient(WasabiRandom random) =>
 		new(VsizeCredentialIssuerParameters, random, CoinjoinState.Parameters.MaxVsizeCredentialValue);

--- a/WalletWasabi/WabiSabi/ProtocolConstants.cs
+++ b/WalletWasabi/WabiSabi/ProtocolConstants.cs
@@ -3,7 +3,7 @@ namespace WalletWasabi.WabiSabi;
 public static class ProtocolConstants
 {
 	public const int CredentialNumber = 2;
-	public const long MaxAmountPerAlice = 4_300_000_000_000L;
+	public const long MaxAmountCredentialValue = 43000_0000_0000L;
 	public const long MaxVsizeCredentialValue = 255;
 
 	public const string WabiSabiProtocolIdentifier = "WabiSabi_v1.0";


### PR DESCRIPTION
ProtocolConstants.MaxAmountPerAlice -> MaxAmountCredentialValue
LiveServerTest
RoundId generation doesn't use the fee value (Wasabi compatibility)