### PR TITLE
Fix WabiSabi type coinjoin detection

### DIFF
--- a/WalletWasabi/Blockchain/Transactions/SmartTransaction.cs
+++ b/WalletWasabi/Blockchain/Transactions/SmartTransaction.cs
@@ -55,7 +55,7 @@ public class SmartTransaction : IEquatable<SmartTransaction>
 		_outputValues = new Lazy<long[]>(() => Transaction.Outputs.Select(x => x.Value.Satoshi).ToArray(), true);
 		_isWasabi2Cj = new Lazy<bool>(
 			() => Transaction.Outputs.Count >= 2 // Sanity check.
-			&& Transaction.Inputs.Count >= 50 // 50 was the minimum input count at the beginning of Wasabi 2.
+			&& Transaction.Inputs.Count >= 21
 			&& OutputValues.Count(x => BlockchainAnalyzer.StdDenoms.Contains(x)) > OutputValues.Length * 0.8 // Most of the outputs contains the denomination.
 			&& OutputValues.Zip(OutputValues.Skip(1)).All(p => p.First >= p.Second), // Outputs are ordered descending.
 			isThreadSafe: true);


### PR DESCRIPTION
The minimum input count for a WabiSabi coinjoin is 21. Not recognizing the WabiSabi coinjoin leads to penalty during the privacy calculation.