### PR TITLE
Remove BigInputMinimum penalty

### DIFF
--- a/WalletWasabi.Tests/UnitTests/BlockchainAnalysis/CoinJoinAnonscoreTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BlockchainAnalysis/CoinJoinAnonscoreTests.cs
@@ -314,6 +314,7 @@ public class CoinJoinAnonScoreTests
 		Assert.Equal(weightedAverage, change.AnonymitySet, precision: 0);
 	}
 
+	/*
 	[Fact]
 	public void InputMergeLargeUniqueDenom()
 	{
@@ -343,7 +344,8 @@ public class CoinJoinAnonScoreTests
 		Assert.NotEqual(weightedAverage, change.AnonymitySet, precision: 0);
 		Assert.Equal(maxPunishment, change.AnonymitySet, precision: 0);
 	}
-
+	*/
+	/*
 	[Fact]
 	public void InputMergeLargeUniqueDenomReasonablePunishment()
 	{
@@ -372,7 +374,8 @@ public class CoinJoinAnonScoreTests
 		Assert.NotEqual(weightedAverage, change.AnonymitySet, precision: 0);
 		Assert.Equal(3, change.AnonymitySet, precision: 0);
 	}
-
+	*/
+	/*
 	[Fact]
 	public void InputMergeLargeUniqueDenomsReasonablePunishment()
 	{
@@ -408,6 +411,7 @@ public class CoinJoinAnonScoreTests
 		Assert.Equal(3, tx.WalletOutputs.Where(x => x.Amount == Money.Coins(20m)).Skip(1).First().AnonymitySet, precision: 0);
 		Assert.Equal(3, tx.WalletOutputs.First(x => x.Amount == Money.Coins(50m)).AnonymitySet, precision: 0);
 	}
+	*/
 
 	[Fact]
 	public void SiblingCoinjoinDoesntContributeToAnonScore()

--- a/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
+++ b/WalletWasabi/Blockchain/Analysis/BlockchainAnalyzer.cs
@@ -94,18 +94,21 @@ public class BlockchainAnalyzer
 		// For cases when it isn't we calculate the rest.
 		CalculateWeightedAverage(tx, cjAnal, out double mixedAnonScore, out double mixedAnonScoreSanctioned);
 		CalculateMinAnonScore(tx, cjAnal, out double nonMixedAnonScore, out double nonMixedAnonScoreSanctioned);
-		CalculateHalfMixedAnonScore(tx, cjAnal, mixedAnonScore, mixedAnonScoreSanctioned, out double halfMixedAnonScore, out double halfMixedAnonScoreSanctioned);
+		//CalculateHalfMixedAnonScore(tx, cjAnal, mixedAnonScore, mixedAnonScoreSanctioned, out double halfMixedAnonScore, out double halfMixedAnonScoreSanctioned);
 
 		startingAnonScores = new()
 		{
 			Minimum = (nonMixedAnonScore, nonMixedAnonScoreSanctioned),
-			BigInputMinimum = (halfMixedAnonScore, halfMixedAnonScoreSanctioned),
+			BigInputMinimum = (mixedAnonScore, mixedAnonScoreSanctioned),
 			WeightedAverage = (mixedAnonScore, mixedAnonScoreSanctioned)
 		};
 	}
 
 	private static void CalculateHalfMixedAnonScore(SmartTransaction tx, CoinjoinAnalyzer cjAnal, double mixedAnonScore, double mixedAnonScoreSanctioned, out double halfMixedAnonScore, out double halfMixedAnonScoreSanctioned)
 	{
+		// This is buggy and not consistent as it will not recognize the users' input if it is the 2nd, 3rd etc. in the list, but with the same amount
+		// No immediate fix possible as we don't know the non-wallet inputs' amount
+
 		// Calculate punishment to the smallest anonscore input from the largest inputs.
 		// We know WW2 coinjoins order inputs by amount.
 		var ourLargeHdPubKeys = new HashSet<HdPubKey>();
@@ -272,6 +275,7 @@ public class BlockchainAnalyzer
 			.ToDictionary(x => x.Key, y => y.Count())
 			.Select(x => (x.Key, x.Value))
 			.Where(x => x.Value > 1)
+			.OrderByDescending(x => x.Key)
 			.FirstOrDefault().Key;
 
 		largestEqualForeignOutputAmount = found == default ? null : found;


### PR DESCRIPTION
The privacy penalty for big input minimum is inconsistent as it is not able to recognize the users' input if it is the 2nd, 3rd etc. in the input list, but with the same amount. Fixing it is problematic as the amounts of the foreign inputs are not available.