### PR TITLE
Allow persistent custom MainNet backend URI from config file

### DIFF
--- a/WaletWasabi/Lang/Resources.Designer.cs
+++ b/WaletWasabi/Lang/Resources.Designer.cs
@@ -6252,16 +6252,27 @@ namespace WalletWasabi.Lang {
                 return ResourceManager.GetString("WasabiDownloadBlocksFromFullNode", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Ginger will download blocks from a full node you control..
+        /// </summary>
+        public static string NetBackendUri {
+            get {
+                return ResourceManager.GetString("NetBackendUri", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Website (Clearnet).
         /// </summary>
-        public static string WebsiteClearnet {
-            get {
+        public static string WebsiteClearnet
+        {
+            get
+            {
                 return ResourceManager.GetString("WebsiteClearnet", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Weeks.
         /// </summary>

--- a/WalletWasabi.Daemon/PersistentConfig.cs
+++ b/WalletWasabi.Daemon/PersistentConfig.cs
@@ -29,12 +29,12 @@ public record PersistentConfig : IConfigNg
 	[DefaultValue(Constants.BackendUri)]
 	[JsonPropertyName("MainNetBackendUri")]
 	[JsonConverter(typeof(MainNetBackendUriJsonConverter))]
-	public string MainNetBackendUri { get; init; } = Constants.BackendUri;
+	public string MainNetBackendUri { get; set; } = Constants.BackendUri;
 
 	[DefaultValue(Constants.TestnetBackendUri)]
 	[JsonPropertyName("TestNetClearnetBackendUri")]
 	[JsonConverter(typeof(TestNetBackendUriJsonConverter))]
-	public string TestNetBackendUri { get; init; } = Constants.TestnetBackendUri;
+	public string TestNetBackendUri { get; set; } = Constants.TestnetBackendUri;
 
 	[DefaultValue("http://localhost:37127/")]
 	[JsonPropertyName("RegTestBackendUri")]
@@ -242,6 +242,7 @@ public record PersistentConfig : IConfigNg
 	{
 		bool hasChanged = false;
 
+		/*
 		if (config.MainNetBackendUri != Constants.BackendUri || config.MainNetCoordinatorUri != Constants.BackendUri)
 		{
 			hasChanged = true;
@@ -251,6 +252,7 @@ public record PersistentConfig : IConfigNg
 				MainNetCoordinatorUri = Constants.BackendUri
 			};
 		}
+		*/
 
 		// Previous imports from Wasabi could increase this to 100. We do want to check and change this, even if we are not readFromWasabi.
 		if (config.AbsoluteMinInputCount > Constants.DefaultAbsoluteMinInputCount)

--- a/WalletWasabi.Fluent/Settings/Views/BitcoinTabSettingsView.axaml
+++ b/WalletWasabi.Fluent/Settings/Views/BitcoinTabSettingsView.axaml
@@ -29,6 +29,16 @@
       </ComboBox>
     </DockPanel>
 
+    <DockPanel IsVisible="true"
+               ToolTip.Tip="{x:Static lang:Resources.NetBackendUri}">
+      <TextBlock Text="{x:Static lang:Resources.NetBackendUri}" />
+      <TextBox Text="{Binding Settings.NetBackendUri}">
+        <Interaction.Behaviors>
+          <TextBoxAutoSelectTextBehavior />
+        </Interaction.Behaviors>
+      </TextBox>
+    </DockPanel>
+
     <DockPanel>
       <TextBlock Text="{x:Static lang:Resources.RunBitcoinKnotsOnStartup}" />
       <ToggleSwitch IsChecked="{Binding Settings.StartLocalBitcoinCoreOnStartup}" />

--- a/WalletWasabi/JsonConverters/MainNetBackendUriJsonConverter.cs
+++ b/WalletWasabi/JsonConverters/MainNetBackendUriJsonConverter.cs
@@ -11,7 +11,14 @@ public class MainNetBackendUriJsonConverter : JsonConverter<string>
 {
 	public override string? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{
-		return Constants.BackendUri;
+		if (reader.TokenType == JsonTokenType.String)
+		{
+			return reader.GetString();
+		}
+		else
+		{
+			return Constants.BackendUri;
+		}
 	}
 
 	public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)

--- a/WalletWasabi/JsonConverters/TestNetBackendUriJsonConverter.cs
+++ b/WalletWasabi/JsonConverters/TestNetBackendUriJsonConverter.cs
@@ -11,7 +11,14 @@ public class TestNetBackendUriJsonConverter : JsonConverter<string>
 {
 	public override string? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{
-		return Constants.TestnetBackendUri;
+		if (reader.TokenType == JsonTokenType.String)
+		{
+			return reader.GetString();
+		}
+		else
+		{
+			return Constants.TestnetBackendUri;
+		}
 	}
 
 	public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)

--- a/WalletWasabi/Lang/Resources.de.resx
+++ b/WalletWasabi/Lang/Resources.de.resx
@@ -2050,6 +2050,9 @@
     <data name="WasabiDownloadBlocksFromFullNode" xml:space="preserve">
         <value>Ginger lädt Blöcke von einem full Node, den Du kontrollierst.</value>
     </data>
+    <data name="NetBackendUri" xml:space="preserve">
+        <value>Koordinator-API-Adresse</value>
+    </data>
     <data name="WebsiteClearnet" xml:space="preserve">
         <value>Website (Clearnet)</value>
     </data>

--- a/WalletWasabi/Lang/Resources.es.resx
+++ b/WalletWasabi/Lang/Resources.es.resx
@@ -852,6 +852,9 @@
   <data name="WasabiDownloadBlocksFromFullNode" xml:space="preserve">
     <value>Ginger descargará bloques desde un full node que controlas.</value>
   </data>
+  <data name="NetBackendUri" xml:space="preserve">
+    <value>Dirección API del coordinador</value>
+  </data>
   <data name="BitcoinP2PEndpoint" xml:space="preserve">
     <value>Punto final P2P de Bitcoin</value>
   </data>

--- a/WalletWasabi/Lang/Resources.fr.resx
+++ b/WalletWasabi/Lang/Resources.fr.resx
@@ -843,6 +843,9 @@
   <data name="WasabiDownloadBlocksFromFullNode" xml:space="preserve">
     <value>Ginger va télécharger les blocks depuis un noeud complet que vous contrôlez.</value>
   </data>
+  <data name="NetBackendUri" xml:space="preserve">
+    <value>Adresse API du coordinateur</value>
+  </data>
   <data name="BitcoinP2PEndpoint" xml:space="preserve">
     <value>Point final de P2P Bitcoin</value>
   </data>

--- a/WalletWasabi/Lang/Resources.hu.resx
+++ b/WalletWasabi/Lang/Resources.hu.resx
@@ -849,6 +849,9 @@
   <data name="WasabiDownloadBlocksFromFullNode" xml:space="preserve">
     <value>A Ginger egy Full Node-tól tölt le blokkokat, amelyet te vezérelsz.</value>
   </data>
+  <data name="NetBackendUri" xml:space="preserve">
+    <value>Koordinátor API-cím</value>
+  </data>
   <data name="BitcoinP2PEndpoint" xml:space="preserve">
     <value>Bitcoin P2P végpont</value>
   </data>

--- a/WalletWasabi/Lang/Resources.it.resx
+++ b/WalletWasabi/Lang/Resources.it.resx
@@ -852,6 +852,9 @@
   <data name="WasabiDownloadBlocksFromFullNode" xml:space="preserve">
     <value>Ginger scaricherà i blocchi da un Full Node che controlli.</value>
   </data>
+  <data name="NetBackendUri" xml:space="preserve">
+    <value>Indirizzo delle API del coordinator</value>
+  </data>
   <data name="BitcoinP2PEndpoint" xml:space="preserve">
     <value>Bitcoin P2P Endpoint</value>
   </data>

--- a/WalletWasabi/Lang/Resources.pt.resx
+++ b/WalletWasabi/Lang/Resources.pt.resx
@@ -2050,6 +2050,9 @@
     <data name="WasabiDownloadBlocksFromFullNode" xml:space="preserve">
         <value>O Ginger fará o download de blocos de um nó completo que você controla.</value>
     </data>
+    <data name="NetBackendUri" xml:space="preserve">
+        <value>Endereço da API do Coordenador</value>
+    </data>
     <data name="WebsiteClearnet" xml:space="preserve">
         <value>Website (Clearnet)</value>
     </data>

--- a/WalletWasabi/Lang/Resources.resx
+++ b/WalletWasabi/Lang/Resources.resx
@@ -853,6 +853,9 @@
   <data name="WasabiDownloadBlocksFromFullNode" xml:space="preserve">
     <value>Ginger will download blocks from a full node you control.</value>
   </data>
+  <data name="NetBackendUri" xml:space="preserve">
+    <value>Coordinator API Address</value>
+  </data>
   <data name="BitcoinP2PEndpoint" xml:space="preserve">
     <value>Bitcoin P2P Endpoint</value>
   </data>

--- a/WalletWasabi/Lang/Resources.tr.resx
+++ b/WalletWasabi/Lang/Resources.tr.resx
@@ -2050,6 +2050,9 @@
     <data name="WasabiDownloadBlocksFromFullNode" xml:space="preserve">
         <value>Ginger, kontrol ettiğiniz tam bir Full Node'den indirilecektir.</value>
     </data>
+    <data name="NetBackendUri" xml:space="preserve">
+        <value>Koordinatör API Adresi</value>
+    </data>
     <data name="WebsiteClearnet" xml:space="preserve">
         <value>Web sitesi (Clearnet)</value>
     </data>

--- a/WalletWasabi/Lang/Resources.zh.resx
+++ b/WalletWasabi/Lang/Resources.zh.resx
@@ -849,6 +849,9 @@
   <data name="WasabiDownloadBlocksFromFullNode" xml:space="preserve">
     <value>Ginger从您控制的全节点同步区块数据。</value>
   </data>
+  <data name="NetBackendUri" xml:space="preserve">
+      <value>协调器 API 地址</value>
+  </data>
   <data name="BitcoinP2PEndpoint" xml:space="preserve">
     <value>Bitcoin P2P 节点地址</value>
   </data>


### PR DESCRIPTION
Some weeks ago I had a problem using predefined MainNet (api.gingerwallet.io), I believe there was some networking issue or the net was down for some reason. I then looked at the GUI for an option to change it, and I have tried to change in the Config.json.
Both failed: the GUI has no option, and the change in the Config.json is ignored and restored to the default.

So I have done this minor change to allow a user to change the default MainNet from the Config.json

Sending this PR because it can help other user, if it happens that api.gingerwallet.io is down or not reachable.