### PR TITLE
Update low-risk package versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,23 +5,23 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- AspNetCore. -->
-    <PackageVersion Include="Markdown.Avalonia" Version="11.0.3-a1" />
-    <PackageVersion Include="Microsoft.AspNetCore.ResponseCompression" Version="2.3.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="8.0.19" />
+    <PackageVersion Include="Markdown.Avalonia" Version="11.0.3" />
+    <PackageVersion Include="Microsoft.AspNetCore.ResponseCompression" Version="2.3.11" />
+    <PackageVersion Include="Microsoft.AspNetCore.WebUtilities" Version="8.0.28" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="8.0.1" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="System.IO.Pipelines" Version="8.0.0" />
     <!-- Nostr-->
     <PackageVersion Include="NNostr.Client" Version="0.0.54" />
     <!-- JSON. -->
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.19" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.28" />
     <!-- SQLite. -->
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="8.0.19" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="8.0.28" />
     <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
     <PackageVersion Include="Microsoft.Win32.SystemEvents" Version="8.0.0" />
     <!-- C# analysis. -->
@@ -36,7 +36,7 @@
     <PackageVersion Include="WabiSabi" Version="1.0.1.2" />
     <PackageVersion Include="NBitcoin" Version="9.0.0" />
     <!-- Backend. -->
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.9.0" />
     <!-- UI. -->
     <PackageVersion Include="Avalonia" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Controls.TreeDataGrid" Version="11.1.0" />
@@ -59,8 +59,8 @@
     <!-- UI Testing. -->
     <PackageVersion Include="Avalonia.Headless.XUnit" Version="$(AvaloniaVersion)" />
     <!-- Testing. -->
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.19" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.28" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/GingerCommon/packages.lock.json
+++ b/GingerCommon/packages.lock.json
@@ -58,9 +58,9 @@
       },
       "Newtonsoft.Json": {
         "type": "Direct",
-        "requested": "[13.0.3, )",
-        "resolved": "13.0.3",
-        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+        "requested": "[13.0.4, )",
+        "resolved": "13.0.4",
+        "contentHash": "pdgNNMai3zv51W5aq268sujXUyx7SNdE2bj1wZcWjAQrKMFZV260lbqYop1d2GM67JI1huLRwxo9ZqnfF/lC6A=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",

--- a/WalletWasabi.Daemon/packages.lock.json
+++ b/WalletWasabi.Daemon/packages.lock.json
@@ -44,8 +44,8 @@
       },
       "Microsoft.Data.Sqlite.Core": {
         "type": "Transitive",
-        "resolved": "8.0.19",
-        "contentHash": "ugQbXR+SwaFHXkfMW+Q6Dn9VSQn6uUoaFp49Zqe+EQGDNMb8dviFCratqnRiBXZKAqt2aFRsV+Cj5gqcTWU/dA==",
+        "resolved": "8.0.28",
+        "contentHash": "tBFB6FTHmKPpNpZbm79asyQ5A84QR81u1co4S3TQMqaN/e8eQHtc7rEZQclWy5HliLzxXz7yEnktKJRa7gQZyw==",
         "dependencies": {
           "SQLitePCLRaw.core": "2.1.6"
         }
@@ -176,8 +176,8 @@
       },
       "Microsoft.Net.Http.Headers": {
         "type": "Transitive",
-        "resolved": "8.0.19",
-        "contentHash": "f2hSRVq5rR97YlfGcScVMXJvQpNpbbpnZjwsZ4kmN5/T3xk9DBVt1SPZDJIPrp/sSfdjz8aQtD8jKLXHyoHVng==",
+        "resolved": "8.0.28",
+        "contentHash": "SSN+lIVFTV97WUujUyEChnfjuTo5fKI3F1s2cKsueqai1QY3chzZQouYBZitxXWrD8qf44Z75Iy1tuQWZKNHcQ==",
         "dependencies": {
           "Microsoft.Extensions.Primitives": "8.0.0"
         }
@@ -241,15 +241,15 @@
           "Microsoft.Extensions.Logging.Console": "[8.0.1, )",
           "Microsoft.Extensions.Logging.Debug": "[8.0.1, )",
           "NBitcoin": "[9.0.0, )",
-          "Newtonsoft.Json": "[13.0.3, )"
+          "Newtonsoft.Json": "[13.0.4, )"
         }
       },
       "walletwasabi": {
         "type": "Project",
         "dependencies": {
           "GingerCommon": "[1.0.0, )",
-          "Microsoft.AspNetCore.WebUtilities": "[8.0.19, )",
-          "Microsoft.Data.Sqlite": "[8.0.19, )",
+          "Microsoft.AspNetCore.WebUtilities": "[8.0.28, )",
+          "Microsoft.Data.Sqlite": "[8.0.28, )",
           "Microsoft.Extensions.Caching.Abstractions": "[8.0.0, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[8.0.1, )",
           "Microsoft.Extensions.Http": "[8.0.1, )",
@@ -264,21 +264,21 @@
       },
       "Microsoft.AspNetCore.WebUtilities": {
         "type": "CentralTransitive",
-        "requested": "[8.0.19, )",
-        "resolved": "8.0.19",
-        "contentHash": "fB3ikXAlz6yQuy029zDAS3J4qW3o6HQYL+kqsTjhiog1JwgpfkRTELCTGxMv7fL6VljFtfNJIQ/2684soCuI9A==",
+        "requested": "[8.0.28, )",
+        "resolved": "8.0.28",
+        "contentHash": "pXPP85yKDxFurpRWvXwSGvg0Arxw8wW8zdroHdGTZ9oE3KN8U4yPbTiArGQUDJHS/HBIYf/gK88QAHXrNmcmuw==",
         "dependencies": {
-          "Microsoft.Net.Http.Headers": "8.0.19",
+          "Microsoft.Net.Http.Headers": "8.0.28",
           "System.IO.Pipelines": "8.0.0"
         }
       },
       "Microsoft.Data.Sqlite": {
         "type": "CentralTransitive",
-        "requested": "[8.0.19, )",
-        "resolved": "8.0.19",
-        "contentHash": "GcYP5qUdpnF3FPoVZ6EewQ7EESRWuX79pTBYxRo/KCCiz9HTDtTka0FH+h3fUGJqk21nc0Q9BApThywO1enFaw==",
+        "requested": "[8.0.28, )",
+        "resolved": "8.0.28",
+        "contentHash": "YM522Q363v0GBq/3xpjWvUALurnwxDoAhhihlYoWhkBQ98XHQxZf01IOwLiUaWFl3PL45PLa4Wbm3FqyijMZGg==",
         "dependencies": {
-          "Microsoft.Data.Sqlite.Core": "8.0.19",
+          "Microsoft.Data.Sqlite.Core": "8.0.28",
           "SQLitePCLRaw.bundle_e_sqlite3": "2.1.6"
         }
       },
@@ -360,9 +360,9 @@
       },
       "Newtonsoft.Json": {
         "type": "CentralTransitive",
-        "requested": "[13.0.3, )",
-        "resolved": "13.0.3",
-        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+        "requested": "[13.0.4, )",
+        "resolved": "13.0.4",
+        "contentHash": "pdgNNMai3zv51W5aq268sujXUyx7SNdE2bj1wZcWjAQrKMFZV260lbqYop1d2GM67JI1huLRwxo9ZqnfF/lC6A=="
       },
       "NNostr.Client": {
         "type": "CentralTransitive",

--- a/WalletWasabi.Fluent.Desktop/packages.lock.json
+++ b/WalletWasabi.Fluent.Desktop/packages.lock.json
@@ -207,17 +207,17 @@
       },
       "ColorDocument.Avalonia": {
         "type": "Transitive",
-        "resolved": "11.0.3-a1",
-        "contentHash": "nFWvafA7sRsTztrYtLqPKnL0EQ/nHz0Vf3xx8q5v8kY/8RFD9uFv7NKhj4niAdama/ej2GlBZW8x477LJlHySQ==",
+        "resolved": "11.0.3",
+        "contentHash": "3lKt5G7v7nHMZOQ7fbLRb8DgpLw3lC7lELWEErPnFS1nblT4MbV9kzPZXQ7G4NcE8vpEjU01gw6dDfRIy65NBA==",
         "dependencies": {
           "Avalonia": "11.0.0",
-          "ColorTextBlock.Avalonia": "11.0.3-a1"
+          "ColorTextBlock.Avalonia": "11.0.3"
         }
       },
       "ColorTextBlock.Avalonia": {
         "type": "Transitive",
-        "resolved": "11.0.3-a1",
-        "contentHash": "eEVGVPe+r0llDaeJHJw4zbK48LQMgqwV2vBL0njUUEJSuqiqqbn32A2xkEQLd/TXePPcxjMzsauwQVec3a/75w==",
+        "resolved": "11.0.3",
+        "contentHash": "oqj4yK4jD4XIvGJiTIh97+fVMVUHVWQZIdG+8PbENBkmLTg9TkZMga+hm8SOwB+W/r6m0coSmoH7NUMz2Wn6lg==",
         "dependencies": {
           "Avalonia": "11.0.0"
         }
@@ -278,30 +278,31 @@
       },
       "Markdown.Avalonia.Html": {
         "type": "Transitive",
-        "resolved": "11.0.3-a1",
-        "contentHash": "ZGJ7QHsO1G6MofgwiBPuhVufXnhfFfrLRHXwcQ4UPxqpJxRgqjYUnhqc5zvmQDCR7yh5YG918xGAYZxmChJkJA==",
+        "resolved": "11.0.3",
+        "contentHash": "/AGoL4soYQLVMzlnKYQmd4QWSAIYQVdp/6mnAdMPqnfrFSd8oXs0sHUvh1IRf+MwcPkrxunNrtDYmKu684y6ZA==",
         "dependencies": {
           "Avalonia": "11.0.0",
-          "ColorTextBlock.Avalonia": "11.0.3-a1",
+          "ColorDocument.Avalonia": "11.0.3",
+          "ColorTextBlock.Avalonia": "11.0.3",
           "HtmlAgilityPack": "1.11.42",
-          "Markdown.Avalonia.SyntaxHigh": "11.0.3-a1",
-          "Markdown.Avalonia.Tight": "11.0.3-a1"
+          "Markdown.Avalonia.SyntaxHigh": "11.0.3",
+          "Markdown.Avalonia.Tight": "11.0.3"
         }
       },
       "Markdown.Avalonia.Svg": {
         "type": "Transitive",
-        "resolved": "11.0.3-a1",
-        "contentHash": "1kBIAx1WWVtDKXqLNXm1x5vRGnqHcwffOzq74p1MYX49AZO+++xMuxwjq/zeH48sHbOVwb2eTp58afdDyx/XEQ==",
+        "resolved": "11.0.3",
+        "contentHash": "R/043ura/6Q5QfmI2KsqkRIKDer6LlZKZ1shy9zZmWqFEPvRc6aeEl2f2VCgkB/TBZt5PhC6hGt7ljmyWHn/eQ==",
         "dependencies": {
           "Avalonia": "11.0.0",
           "Avalonia.Svg": "11.0.0",
-          "Markdown.Avalonia.Tight": "11.0.3-a1"
+          "Markdown.Avalonia.Tight": "11.0.3"
         }
       },
       "Markdown.Avalonia.SyntaxHigh": {
         "type": "Transitive",
-        "resolved": "11.0.3-a1",
-        "contentHash": "DkbcpPaGOMDplXqbpnL0joEoG0wxiQ2gxd3YlCFO4EhtRSZrteQ+o4ZoGcowqgrv1IQEEA0Gpvsw/7Mx9lARxg==",
+        "resolved": "11.0.3",
+        "contentHash": "+DYkzuZwPrm6tJaVqXU5/ke7TKLj5RFzJV9mAQZdxWZTZxLrbEaSVLupjU9YFFwRUi2jdWCrH51OqM14mC3hww==",
         "dependencies": {
           "Avalonia": "11.0.0",
           "Avalonia.AvaloniaEdit": "11.0.0"
@@ -309,12 +310,12 @@
       },
       "Markdown.Avalonia.Tight": {
         "type": "Transitive",
-        "resolved": "11.0.3-a1",
-        "contentHash": "FBDzAOvDitTYftA0RZ2luIkcqWt5IXn67gR2guTBJka9Fn6QApHnAGbHqQWmo+R4Is/zi5s5zMoBNULK1AjyEQ==",
+        "resolved": "11.0.3",
+        "contentHash": "yV61pNsz8GfVzaNy2IM/K6eGEoL5J0uqPY3TCpWfVpwkH9gZEi48BIhoY3Lz/fmqbLR74aE2s1/N01z7jZQavQ==",
         "dependencies": {
           "Avalonia": "11.0.0",
-          "ColorDocument.Avalonia": "11.0.3-a1",
-          "ColorTextBlock.Avalonia": "11.0.3-a1"
+          "ColorDocument.Avalonia": "11.0.3",
+          "ColorTextBlock.Avalonia": "11.0.3"
         }
       },
       "MicroCom.Runtime": {
@@ -329,8 +330,8 @@
       },
       "Microsoft.Data.Sqlite.Core": {
         "type": "Transitive",
-        "resolved": "8.0.19",
-        "contentHash": "ugQbXR+SwaFHXkfMW+Q6Dn9VSQn6uUoaFp49Zqe+EQGDNMb8dviFCratqnRiBXZKAqt2aFRsV+Cj5gqcTWU/dA==",
+        "resolved": "8.0.28",
+        "contentHash": "tBFB6FTHmKPpNpZbm79asyQ5A84QR81u1co4S3TQMqaN/e8eQHtc7rEZQclWy5HliLzxXz7yEnktKJRa7gQZyw==",
         "dependencies": {
           "SQLitePCLRaw.core": "2.1.6"
         }
@@ -461,8 +462,8 @@
       },
       "Microsoft.Net.Http.Headers": {
         "type": "Transitive",
-        "resolved": "8.0.19",
-        "contentHash": "f2hSRVq5rR97YlfGcScVMXJvQpNpbbpnZjwsZ4kmN5/T3xk9DBVt1SPZDJIPrp/sSfdjz8aQtD8jKLXHyoHVng==",
+        "resolved": "8.0.28",
+        "contentHash": "SSN+lIVFTV97WUujUyEChnfjuTo5fKI3F1s2cKsueqai1QY3chzZQouYBZitxXWrD8qf44Z75Iy1tuQWZKNHcQ==",
         "dependencies": {
           "Microsoft.Extensions.Primitives": "8.0.0"
         }
@@ -751,15 +752,15 @@
           "Microsoft.Extensions.Logging.Console": "[8.0.1, )",
           "Microsoft.Extensions.Logging.Debug": "[8.0.1, )",
           "NBitcoin": "[9.0.0, )",
-          "Newtonsoft.Json": "[13.0.3, )"
+          "Newtonsoft.Json": "[13.0.4, )"
         }
       },
       "walletwasabi": {
         "type": "Project",
         "dependencies": {
           "GingerCommon": "[1.0.0, )",
-          "Microsoft.AspNetCore.WebUtilities": "[8.0.19, )",
-          "Microsoft.Data.Sqlite": "[8.0.19, )",
+          "Microsoft.AspNetCore.WebUtilities": "[8.0.28, )",
+          "Microsoft.Data.Sqlite": "[8.0.28, )",
           "Microsoft.Extensions.Caching.Abstractions": "[8.0.0, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[8.0.1, )",
           "Microsoft.Extensions.Http": "[8.0.1, )",
@@ -784,7 +785,7 @@
           "Avalonia.Themes.Fluent": "[11.3.2, )",
           "Avalonia.Xaml.Behaviors": "[11.0.5, )",
           "DynamicData": "[8.4.1, )",
-          "Markdown.Avalonia": "[11.0.3-a1, )",
+          "Markdown.Avalonia": "[11.0.3, )",
           "QRackers": "[1.1.0, )",
           "System.Private.Uri": "[4.3.2, )",
           "System.Runtime": "[4.3.1, )",
@@ -893,33 +894,33 @@
       },
       "Markdown.Avalonia": {
         "type": "CentralTransitive",
-        "requested": "[11.0.3-a1, )",
-        "resolved": "11.0.3-a1",
-        "contentHash": "KtqVVB/2c6F5yB+juGjIPg8PHZ+7nXh9O1bdsR223Wq+H6G72cOnMbjEE+uX1+K4SOPlTPHVDci9CvcfXI4sZg==",
+        "requested": "[11.0.3, )",
+        "resolved": "11.0.3",
+        "contentHash": "z1eLnzv+FWquHaiFOGXd5+i8fa9sm4NbK+rr/6bTIk+HnXrt/asvgNfIrDVei2Bsy3f4Mjx7AyeiVnEdsxGKZw==",
         "dependencies": {
-          "Markdown.Avalonia.Html": "11.0.3-a1",
-          "Markdown.Avalonia.Svg": "11.0.3-a1",
-          "Markdown.Avalonia.SyntaxHigh": "11.0.3-a1",
-          "Markdown.Avalonia.Tight": "11.0.3-a1"
+          "Markdown.Avalonia.Html": "11.0.3",
+          "Markdown.Avalonia.Svg": "11.0.3",
+          "Markdown.Avalonia.SyntaxHigh": "11.0.3",
+          "Markdown.Avalonia.Tight": "11.0.3"
         }
       },
       "Microsoft.AspNetCore.WebUtilities": {
         "type": "CentralTransitive",
-        "requested": "[8.0.19, )",
-        "resolved": "8.0.19",
-        "contentHash": "fB3ikXAlz6yQuy029zDAS3J4qW3o6HQYL+kqsTjhiog1JwgpfkRTELCTGxMv7fL6VljFtfNJIQ/2684soCuI9A==",
+        "requested": "[8.0.28, )",
+        "resolved": "8.0.28",
+        "contentHash": "pXPP85yKDxFurpRWvXwSGvg0Arxw8wW8zdroHdGTZ9oE3KN8U4yPbTiArGQUDJHS/HBIYf/gK88QAHXrNmcmuw==",
         "dependencies": {
-          "Microsoft.Net.Http.Headers": "8.0.19",
+          "Microsoft.Net.Http.Headers": "8.0.28",
           "System.IO.Pipelines": "8.0.0"
         }
       },
       "Microsoft.Data.Sqlite": {
         "type": "CentralTransitive",
-        "requested": "[8.0.19, )",
-        "resolved": "8.0.19",
-        "contentHash": "GcYP5qUdpnF3FPoVZ6EewQ7EESRWuX79pTBYxRo/KCCiz9HTDtTka0FH+h3fUGJqk21nc0Q9BApThywO1enFaw==",
+        "requested": "[8.0.28, )",
+        "resolved": "8.0.28",
+        "contentHash": "YM522Q363v0GBq/3xpjWvUALurnwxDoAhhihlYoWhkBQ98XHQxZf01IOwLiUaWFl3PL45PLa4Wbm3FqyijMZGg==",
         "dependencies": {
-          "Microsoft.Data.Sqlite.Core": "8.0.19",
+          "Microsoft.Data.Sqlite.Core": "8.0.28",
           "SQLitePCLRaw.bundle_e_sqlite3": "2.1.6"
         }
       },
@@ -1014,9 +1015,9 @@
       },
       "Newtonsoft.Json": {
         "type": "CentralTransitive",
-        "requested": "[13.0.3, )",
-        "resolved": "13.0.3",
-        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+        "requested": "[13.0.4, )",
+        "resolved": "13.0.4",
+        "contentHash": "pdgNNMai3zv51W5aq268sujXUyx7SNdE2bj1wZcWjAQrKMFZV260lbqYop1d2GM67JI1huLRwxo9ZqnfF/lC6A=="
       },
       "NNostr.Client": {
         "type": "CentralTransitive",

--- a/WalletWasabi.Fluent/packages.lock.json
+++ b/WalletWasabi.Fluent/packages.lock.json
@@ -106,14 +106,14 @@
       },
       "Markdown.Avalonia": {
         "type": "Direct",
-        "requested": "[11.0.3-a1, )",
-        "resolved": "11.0.3-a1",
-        "contentHash": "KtqVVB/2c6F5yB+juGjIPg8PHZ+7nXh9O1bdsR223Wq+H6G72cOnMbjEE+uX1+K4SOPlTPHVDci9CvcfXI4sZg==",
+        "requested": "[11.0.3, )",
+        "resolved": "11.0.3",
+        "contentHash": "z1eLnzv+FWquHaiFOGXd5+i8fa9sm4NbK+rr/6bTIk+HnXrt/asvgNfIrDVei2Bsy3f4Mjx7AyeiVnEdsxGKZw==",
         "dependencies": {
-          "Markdown.Avalonia.Html": "11.0.3-a1",
-          "Markdown.Avalonia.Svg": "11.0.3-a1",
-          "Markdown.Avalonia.SyntaxHigh": "11.0.3-a1",
-          "Markdown.Avalonia.Tight": "11.0.3-a1"
+          "Markdown.Avalonia.Html": "11.0.3",
+          "Markdown.Avalonia.Svg": "11.0.3",
+          "Markdown.Avalonia.SyntaxHigh": "11.0.3",
+          "Markdown.Avalonia.Tight": "11.0.3"
         }
       },
       "Microsoft.CodeAnalysis.BannedApiAnalyzers": {
@@ -276,17 +276,17 @@
       },
       "ColorDocument.Avalonia": {
         "type": "Transitive",
-        "resolved": "11.0.3-a1",
-        "contentHash": "nFWvafA7sRsTztrYtLqPKnL0EQ/nHz0Vf3xx8q5v8kY/8RFD9uFv7NKhj4niAdama/ej2GlBZW8x477LJlHySQ==",
+        "resolved": "11.0.3",
+        "contentHash": "3lKt5G7v7nHMZOQ7fbLRb8DgpLw3lC7lELWEErPnFS1nblT4MbV9kzPZXQ7G4NcE8vpEjU01gw6dDfRIy65NBA==",
         "dependencies": {
           "Avalonia": "11.0.0",
-          "ColorTextBlock.Avalonia": "11.0.3-a1"
+          "ColorTextBlock.Avalonia": "11.0.3"
         }
       },
       "ColorTextBlock.Avalonia": {
         "type": "Transitive",
-        "resolved": "11.0.3-a1",
-        "contentHash": "eEVGVPe+r0llDaeJHJw4zbK48LQMgqwV2vBL0njUUEJSuqiqqbn32A2xkEQLd/TXePPcxjMzsauwQVec3a/75w==",
+        "resolved": "11.0.3",
+        "contentHash": "oqj4yK4jD4XIvGJiTIh97+fVMVUHVWQZIdG+8PbENBkmLTg9TkZMga+hm8SOwB+W/r6m0coSmoH7NUMz2Wn6lg==",
         "dependencies": {
           "Avalonia": "11.0.0"
         }
@@ -347,30 +347,31 @@
       },
       "Markdown.Avalonia.Html": {
         "type": "Transitive",
-        "resolved": "11.0.3-a1",
-        "contentHash": "ZGJ7QHsO1G6MofgwiBPuhVufXnhfFfrLRHXwcQ4UPxqpJxRgqjYUnhqc5zvmQDCR7yh5YG918xGAYZxmChJkJA==",
+        "resolved": "11.0.3",
+        "contentHash": "/AGoL4soYQLVMzlnKYQmd4QWSAIYQVdp/6mnAdMPqnfrFSd8oXs0sHUvh1IRf+MwcPkrxunNrtDYmKu684y6ZA==",
         "dependencies": {
           "Avalonia": "11.0.0",
-          "ColorTextBlock.Avalonia": "11.0.3-a1",
+          "ColorDocument.Avalonia": "11.0.3",
+          "ColorTextBlock.Avalonia": "11.0.3",
           "HtmlAgilityPack": "1.11.42",
-          "Markdown.Avalonia.SyntaxHigh": "11.0.3-a1",
-          "Markdown.Avalonia.Tight": "11.0.3-a1"
+          "Markdown.Avalonia.SyntaxHigh": "11.0.3",
+          "Markdown.Avalonia.Tight": "11.0.3"
         }
       },
       "Markdown.Avalonia.Svg": {
         "type": "Transitive",
-        "resolved": "11.0.3-a1",
-        "contentHash": "1kBIAx1WWVtDKXqLNXm1x5vRGnqHcwffOzq74p1MYX49AZO+++xMuxwjq/zeH48sHbOVwb2eTp58afdDyx/XEQ==",
+        "resolved": "11.0.3",
+        "contentHash": "R/043ura/6Q5QfmI2KsqkRIKDer6LlZKZ1shy9zZmWqFEPvRc6aeEl2f2VCgkB/TBZt5PhC6hGt7ljmyWHn/eQ==",
         "dependencies": {
           "Avalonia": "11.0.0",
           "Avalonia.Svg": "11.0.0",
-          "Markdown.Avalonia.Tight": "11.0.3-a1"
+          "Markdown.Avalonia.Tight": "11.0.3"
         }
       },
       "Markdown.Avalonia.SyntaxHigh": {
         "type": "Transitive",
-        "resolved": "11.0.3-a1",
-        "contentHash": "DkbcpPaGOMDplXqbpnL0joEoG0wxiQ2gxd3YlCFO4EhtRSZrteQ+o4ZoGcowqgrv1IQEEA0Gpvsw/7Mx9lARxg==",
+        "resolved": "11.0.3",
+        "contentHash": "+DYkzuZwPrm6tJaVqXU5/ke7TKLj5RFzJV9mAQZdxWZTZxLrbEaSVLupjU9YFFwRUi2jdWCrH51OqM14mC3hww==",
         "dependencies": {
           "Avalonia": "11.0.0",
           "Avalonia.AvaloniaEdit": "11.0.0"
@@ -378,12 +379,12 @@
       },
       "Markdown.Avalonia.Tight": {
         "type": "Transitive",
-        "resolved": "11.0.3-a1",
-        "contentHash": "FBDzAOvDitTYftA0RZ2luIkcqWt5IXn67gR2guTBJka9Fn6QApHnAGbHqQWmo+R4Is/zi5s5zMoBNULK1AjyEQ==",
+        "resolved": "11.0.3",
+        "contentHash": "yV61pNsz8GfVzaNy2IM/K6eGEoL5J0uqPY3TCpWfVpwkH9gZEi48BIhoY3Lz/fmqbLR74aE2s1/N01z7jZQavQ==",
         "dependencies": {
           "Avalonia": "11.0.0",
-          "ColorDocument.Avalonia": "11.0.3-a1",
-          "ColorTextBlock.Avalonia": "11.0.3-a1"
+          "ColorDocument.Avalonia": "11.0.3",
+          "ColorTextBlock.Avalonia": "11.0.3"
         }
       },
       "MicroCom.Runtime": {
@@ -398,8 +399,8 @@
       },
       "Microsoft.Data.Sqlite.Core": {
         "type": "Transitive",
-        "resolved": "8.0.19",
-        "contentHash": "ugQbXR+SwaFHXkfMW+Q6Dn9VSQn6uUoaFp49Zqe+EQGDNMb8dviFCratqnRiBXZKAqt2aFRsV+Cj5gqcTWU/dA==",
+        "resolved": "8.0.28",
+        "contentHash": "tBFB6FTHmKPpNpZbm79asyQ5A84QR81u1co4S3TQMqaN/e8eQHtc7rEZQclWy5HliLzxXz7yEnktKJRa7gQZyw==",
         "dependencies": {
           "SQLitePCLRaw.core": "2.1.6"
         }
@@ -530,8 +531,8 @@
       },
       "Microsoft.Net.Http.Headers": {
         "type": "Transitive",
-        "resolved": "8.0.19",
-        "contentHash": "f2hSRVq5rR97YlfGcScVMXJvQpNpbbpnZjwsZ4kmN5/T3xk9DBVt1SPZDJIPrp/sSfdjz8aQtD8jKLXHyoHVng==",
+        "resolved": "8.0.28",
+        "contentHash": "SSN+lIVFTV97WUujUyEChnfjuTo5fKI3F1s2cKsueqai1QY3chzZQouYBZitxXWrD8qf44Z75Iy1tuQWZKNHcQ==",
         "dependencies": {
           "Microsoft.Extensions.Primitives": "8.0.0"
         }
@@ -820,15 +821,15 @@
           "Microsoft.Extensions.Logging.Console": "[8.0.1, )",
           "Microsoft.Extensions.Logging.Debug": "[8.0.1, )",
           "NBitcoin": "[9.0.0, )",
-          "Newtonsoft.Json": "[13.0.3, )"
+          "Newtonsoft.Json": "[13.0.4, )"
         }
       },
       "walletwasabi": {
         "type": "Project",
         "dependencies": {
           "GingerCommon": "[1.0.0, )",
-          "Microsoft.AspNetCore.WebUtilities": "[8.0.19, )",
-          "Microsoft.Data.Sqlite": "[8.0.19, )",
+          "Microsoft.AspNetCore.WebUtilities": "[8.0.28, )",
+          "Microsoft.Data.Sqlite": "[8.0.28, )",
           "Microsoft.Extensions.Caching.Abstractions": "[8.0.0, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[8.0.1, )",
           "Microsoft.Extensions.Http": "[8.0.1, )",
@@ -851,21 +852,21 @@
       },
       "Microsoft.AspNetCore.WebUtilities": {
         "type": "CentralTransitive",
-        "requested": "[8.0.19, )",
-        "resolved": "8.0.19",
-        "contentHash": "fB3ikXAlz6yQuy029zDAS3J4qW3o6HQYL+kqsTjhiog1JwgpfkRTELCTGxMv7fL6VljFtfNJIQ/2684soCuI9A==",
+        "requested": "[8.0.28, )",
+        "resolved": "8.0.28",
+        "contentHash": "pXPP85yKDxFurpRWvXwSGvg0Arxw8wW8zdroHdGTZ9oE3KN8U4yPbTiArGQUDJHS/HBIYf/gK88QAHXrNmcmuw==",
         "dependencies": {
-          "Microsoft.Net.Http.Headers": "8.0.19",
+          "Microsoft.Net.Http.Headers": "8.0.28",
           "System.IO.Pipelines": "8.0.0"
         }
       },
       "Microsoft.Data.Sqlite": {
         "type": "CentralTransitive",
-        "requested": "[8.0.19, )",
-        "resolved": "8.0.19",
-        "contentHash": "GcYP5qUdpnF3FPoVZ6EewQ7EESRWuX79pTBYxRo/KCCiz9HTDtTka0FH+h3fUGJqk21nc0Q9BApThywO1enFaw==",
+        "requested": "[8.0.28, )",
+        "resolved": "8.0.28",
+        "contentHash": "YM522Q363v0GBq/3xpjWvUALurnwxDoAhhihlYoWhkBQ98XHQxZf01IOwLiUaWFl3PL45PLa4Wbm3FqyijMZGg==",
         "dependencies": {
-          "Microsoft.Data.Sqlite.Core": "8.0.19",
+          "Microsoft.Data.Sqlite.Core": "8.0.28",
           "SQLitePCLRaw.bundle_e_sqlite3": "2.1.6"
         }
       },
@@ -960,9 +961,9 @@
       },
       "Newtonsoft.Json": {
         "type": "CentralTransitive",
-        "requested": "[13.0.3, )",
-        "resolved": "13.0.3",
-        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+        "requested": "[13.0.4, )",
+        "resolved": "13.0.4",
+        "contentHash": "pdgNNMai3zv51W5aq268sujXUyx7SNdE2bj1wZcWjAQrKMFZV260lbqYop1d2GM67JI1huLRwxo9ZqnfF/lC6A=="
       },
       "NNostr.Client": {
         "type": "CentralTransitive",

--- a/WalletWasabi.Packager/packages.lock.json
+++ b/WalletWasabi.Packager/packages.lock.json
@@ -31,8 +31,8 @@
       },
       "Microsoft.Data.Sqlite.Core": {
         "type": "Transitive",
-        "resolved": "8.0.19",
-        "contentHash": "ugQbXR+SwaFHXkfMW+Q6Dn9VSQn6uUoaFp49Zqe+EQGDNMb8dviFCratqnRiBXZKAqt2aFRsV+Cj5gqcTWU/dA==",
+        "resolved": "8.0.28",
+        "contentHash": "tBFB6FTHmKPpNpZbm79asyQ5A84QR81u1co4S3TQMqaN/e8eQHtc7rEZQclWy5HliLzxXz7yEnktKJRa7gQZyw==",
         "dependencies": {
           "SQLitePCLRaw.core": "2.1.6"
         }
@@ -163,8 +163,8 @@
       },
       "Microsoft.Net.Http.Headers": {
         "type": "Transitive",
-        "resolved": "8.0.19",
-        "contentHash": "f2hSRVq5rR97YlfGcScVMXJvQpNpbbpnZjwsZ4kmN5/T3xk9DBVt1SPZDJIPrp/sSfdjz8aQtD8jKLXHyoHVng==",
+        "resolved": "8.0.28",
+        "contentHash": "SSN+lIVFTV97WUujUyEChnfjuTo5fKI3F1s2cKsueqai1QY3chzZQouYBZitxXWrD8qf44Z75Iy1tuQWZKNHcQ==",
         "dependencies": {
           "Microsoft.Extensions.Primitives": "8.0.0"
         }
@@ -228,15 +228,15 @@
           "Microsoft.Extensions.Logging.Console": "[8.0.1, )",
           "Microsoft.Extensions.Logging.Debug": "[8.0.1, )",
           "NBitcoin": "[9.0.0, )",
-          "Newtonsoft.Json": "[13.0.3, )"
+          "Newtonsoft.Json": "[13.0.4, )"
         }
       },
       "walletwasabi": {
         "type": "Project",
         "dependencies": {
           "GingerCommon": "[1.0.0, )",
-          "Microsoft.AspNetCore.WebUtilities": "[8.0.19, )",
-          "Microsoft.Data.Sqlite": "[8.0.19, )",
+          "Microsoft.AspNetCore.WebUtilities": "[8.0.28, )",
+          "Microsoft.Data.Sqlite": "[8.0.28, )",
           "Microsoft.Extensions.Caching.Abstractions": "[8.0.0, )",
           "Microsoft.Extensions.Hosting.Abstractions": "[8.0.1, )",
           "Microsoft.Extensions.Http": "[8.0.1, )",
@@ -251,21 +251,21 @@
       },
       "Microsoft.AspNetCore.WebUtilities": {
         "type": "CentralTransitive",
-        "requested": "[8.0.19, )",
-        "resolved": "8.0.19",
-        "contentHash": "fB3ikXAlz6yQuy029zDAS3J4qW3o6HQYL+kqsTjhiog1JwgpfkRTELCTGxMv7fL6VljFtfNJIQ/2684soCuI9A==",
+        "requested": "[8.0.28, )",
+        "resolved": "8.0.28",
+        "contentHash": "pXPP85yKDxFurpRWvXwSGvg0Arxw8wW8zdroHdGTZ9oE3KN8U4yPbTiArGQUDJHS/HBIYf/gK88QAHXrNmcmuw==",
         "dependencies": {
-          "Microsoft.Net.Http.Headers": "8.0.19",
+          "Microsoft.Net.Http.Headers": "8.0.28",
           "System.IO.Pipelines": "8.0.0"
         }
       },
       "Microsoft.Data.Sqlite": {
         "type": "CentralTransitive",
-        "requested": "[8.0.19, )",
-        "resolved": "8.0.19",
-        "contentHash": "GcYP5qUdpnF3FPoVZ6EewQ7EESRWuX79pTBYxRo/KCCiz9HTDtTka0FH+h3fUGJqk21nc0Q9BApThywO1enFaw==",
+        "requested": "[8.0.28, )",
+        "resolved": "8.0.28",
+        "contentHash": "YM522Q363v0GBq/3xpjWvUALurnwxDoAhhihlYoWhkBQ98XHQxZf01IOwLiUaWFl3PL45PLa4Wbm3FqyijMZGg==",
         "dependencies": {
-          "Microsoft.Data.Sqlite.Core": "8.0.19",
+          "Microsoft.Data.Sqlite.Core": "8.0.28",
           "SQLitePCLRaw.bundle_e_sqlite3": "2.1.6"
         }
       },
@@ -347,9 +347,9 @@
       },
       "Newtonsoft.Json": {
         "type": "CentralTransitive",
-        "requested": "[13.0.3, )",
-        "resolved": "13.0.3",
-        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+        "requested": "[13.0.4, )",
+        "resolved": "13.0.4",
+        "contentHash": "pdgNNMai3zv51W5aq268sujXUyx7SNdE2bj1wZcWjAQrKMFZV260lbqYop1d2GM67JI1huLRwxo9ZqnfF/lC6A=="
       },
       "NNostr.Client": {
         "type": "CentralTransitive",

--- a/WalletWasabi/packages.lock.json
+++ b/WalletWasabi/packages.lock.json
@@ -4,11 +4,11 @@
     "net8.0": {
       "Microsoft.AspNetCore.WebUtilities": {
         "type": "Direct",
-        "requested": "[8.0.19, )",
-        "resolved": "8.0.19",
-        "contentHash": "fB3ikXAlz6yQuy029zDAS3J4qW3o6HQYL+kqsTjhiog1JwgpfkRTELCTGxMv7fL6VljFtfNJIQ/2684soCuI9A==",
+        "requested": "[8.0.28, )",
+        "resolved": "8.0.28",
+        "contentHash": "pXPP85yKDxFurpRWvXwSGvg0Arxw8wW8zdroHdGTZ9oE3KN8U4yPbTiArGQUDJHS/HBIYf/gK88QAHXrNmcmuw==",
         "dependencies": {
-          "Microsoft.Net.Http.Headers": "8.0.19",
+          "Microsoft.Net.Http.Headers": "8.0.28",
           "System.IO.Pipelines": "8.0.0"
         }
       },
@@ -20,11 +20,11 @@
       },
       "Microsoft.Data.Sqlite": {
         "type": "Direct",
-        "requested": "[8.0.19, )",
-        "resolved": "8.0.19",
-        "contentHash": "GcYP5qUdpnF3FPoVZ6EewQ7EESRWuX79pTBYxRo/KCCiz9HTDtTka0FH+h3fUGJqk21nc0Q9BApThywO1enFaw==",
+        "requested": "[8.0.28, )",
+        "resolved": "8.0.28",
+        "contentHash": "YM522Q363v0GBq/3xpjWvUALurnwxDoAhhihlYoWhkBQ98XHQxZf01IOwLiUaWFl3PL45PLa4Wbm3FqyijMZGg==",
         "dependencies": {
-          "Microsoft.Data.Sqlite.Core": "8.0.19",
+          "Microsoft.Data.Sqlite.Core": "8.0.28",
           "SQLitePCLRaw.bundle_e_sqlite3": "2.1.6"
         }
       },
@@ -142,8 +142,8 @@
       },
       "Microsoft.Data.Sqlite.Core": {
         "type": "Transitive",
-        "resolved": "8.0.19",
-        "contentHash": "ugQbXR+SwaFHXkfMW+Q6Dn9VSQn6uUoaFp49Zqe+EQGDNMb8dviFCratqnRiBXZKAqt2aFRsV+Cj5gqcTWU/dA==",
+        "resolved": "8.0.28",
+        "contentHash": "tBFB6FTHmKPpNpZbm79asyQ5A84QR81u1co4S3TQMqaN/e8eQHtc7rEZQclWy5HliLzxXz7yEnktKJRa7gQZyw==",
         "dependencies": {
           "SQLitePCLRaw.core": "2.1.6"
         }
@@ -274,8 +274,8 @@
       },
       "Microsoft.Net.Http.Headers": {
         "type": "Transitive",
-        "resolved": "8.0.19",
-        "contentHash": "f2hSRVq5rR97YlfGcScVMXJvQpNpbbpnZjwsZ4kmN5/T3xk9DBVt1SPZDJIPrp/sSfdjz8aQtD8jKLXHyoHVng==",
+        "resolved": "8.0.28",
+        "contentHash": "SSN+lIVFTV97WUujUyEChnfjuTo5fKI3F1s2cKsueqai1QY3chzZQouYBZitxXWrD8qf44Z75Iy1tuQWZKNHcQ==",
         "dependencies": {
           "Microsoft.Extensions.Primitives": "8.0.0"
         }
@@ -339,7 +339,7 @@
           "Microsoft.Extensions.Logging.Console": "[8.0.1, )",
           "Microsoft.Extensions.Logging.Debug": "[8.0.1, )",
           "NBitcoin": "[9.0.0, )",
-          "Newtonsoft.Json": "[13.0.3, )"
+          "Newtonsoft.Json": "[13.0.4, )"
         }
       },
       "Microsoft.Extensions.Logging.Console": {
@@ -368,9 +368,9 @@
       },
       "Newtonsoft.Json": {
         "type": "CentralTransitive",
-        "requested": "[13.0.3, )",
-        "resolved": "13.0.3",
-        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+        "requested": "[13.0.4, )",
+        "resolved": "13.0.4",
+        "contentHash": "pdgNNMai3zv51W5aq268sujXUyx7SNdE2bj1wZcWjAQrKMFZV260lbqYop1d2GM67JI1huLRwxo9ZqnfF/lC6A=="
       }
     },
     "net8.0/linux-arm64": {


### PR DESCRIPTION
## Summary

Updates a small set of low-risk package versions after the SQLite security fix.

## Dependency

This PR is built on top of the SQLite security fix branch from PR #1. Because GitHub PR base branches must exist in the upstream repository, this PR currently targets `master`; until PR #1 is merged, GitHub will show the security-fix commit in this diff as well.

## Changes

- Updates .NET 8 ASP.NET package references from `8.0.19` to `8.0.28`.
- Updates `Microsoft.AspNetCore.ResponseCompression` from `2.3.0` to `2.3.11`.
- Updates `Newtonsoft.Json` from `13.0.3` to `13.0.4`.
- Updates `Markdown.Avalonia` from `11.0.3-a1` to stable `11.0.3`.
- Updates `Swashbuckle.AspNetCore` from `6.5.0` to `6.9.0`.
- Updates `Microsoft.NET.Test.Sdk` from `18.0.1` to `18.7.0`.
- Refreshes affected lock files.

## Scope Notes

This intentionally avoids larger-risk upgrades such as .NET 10 package lines, Avalonia 12, NBitcoin 10, and the large Tmds.DBus version jump. Avalonia behavior and TreeDataGrid updates were also excluded because they caused build/API/licensing issues in this codebase.

## Validation

- `dotnet restore .\WalletWasabi.sln`
- `dotnet list .\WalletWasabi.sln package --vulnerable --include-transitive`
- `dotnet build .\WalletWasabi.Backend\WalletWasabi.Backend.csproj --no-restore`
- `dotnet build .\WalletWasabi.Fluent.Desktop\WalletWasabi.Fluent.Desktop.csproj --no-restore`
- `dotnet test .\WalletWasabi.Tests\WalletWasabi.Tests.csproj --no-restore --filter "FullyQualifiedName~Sqlite|FullyQualifiedName~Json|FullyQualifiedName~Serialization"`
