### PR TITLE
[codex] Update CI runtime matrix

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -10,26 +10,37 @@ on:
 
 jobs:
   build:
+    name: Unit tests (${{ matrix.runtime }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-      
+        include:
+          - os: ubuntu-latest
+            runtime: linux-x64
+          - os: windows-latest
+            runtime: win-x64
+          - os: macos-15-intel
+            runtime: osx-x64
+          - os: macos-15
+            runtime: osx-arm64
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
 
       - name: Cache NuGet packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}-${{ hashFiles('**/packages.lock.json') }}
+          key: ${{ runner.os }}-${{ matrix.runtime }}-nuget-${{ hashFiles('**/*.csproj') }}-${{ hashFiles('**/packages.lock.json') }}
           restore-keys: |
+            ${{ runner.os }}-${{ matrix.runtime }}-nuget-
             ${{ runner.os }}-nuget-
 
       - name: Install dependencies

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -50,5 +50,5 @@ jobs:
         run: dotnet build --no-restore --configuration Release
 
       - name: Test
-        run: dotnet test --no-restore --configuration Release --filter "UnitTests" --logger "console;verbosity=detailed"
+        run: dotnet test --no-restore --no-build --configuration Release --filter "UnitTests" --logger "console;verbosity=minimal"
         


### PR DESCRIPTION
## Summary

- expands the UnitTests GitHub Actions matrix from 3 generic OS runners to 4 explicit runtime environments
- adds separate macOS Intel and macOS ARM64 jobs
- updates checkout/setup-dotnet/cache actions to v4 and pins .NET setup to 8.0.x

## Why

The macOS ARM64 packaging work introduces a distinct `osx-arm64` runtime path. The CI should make that runtime visible instead of relying on a generic `macos-latest` job.

## Validation

- `git diff --check`
- `dotnet restore WalletWasabi.sln --locked-mode`
- `dotnet build WalletWasabi.Tests/WalletWasabi.Tests.csproj --configuration Release --no-restore`
- `dotnet test WalletWasabi.Tests/WalletWasabi.Tests.csproj --configuration Release --no-build --filter "UnitTests" --logger "console;verbosity=minimal" --logger "trx;LogFileName=unit-tests.trx"`

Local test result: 952 passed, 0 failed, 0 skipped.