### PR TITLE
Improve Bitcoin Core status diagnostics

### DIFF
--- a/WalletWasabi.Fluent/Converters/StatusConverters.cs
+++ b/WalletWasabi.Fluent/Converters/StatusConverters.cs
@@ -25,7 +25,7 @@ public static class StatusConverters
 		});
 
 	public static readonly IValueConverter RpcStatusStringConverter =
-		new FuncValueConverter<RpcStatus?, string>(status => status is null ? RpcStatus.Unresponsive.ToString() : status.ToString());
+		new FuncValueConverter<RpcStatus?, string>(status => status is null ? RpcStatus.Connecting.ToString() : status.ToString());
 
 	public static readonly IValueConverter PeerStatusStringConverter =
 		new FuncValueConverter<int, string>(peerCount => Resources.PeersConnected.SafeInject(peerCount));

--- a/WalletWasabi.Tests/UnitTests/MockRpcClient.cs
+++ b/WalletWasabi.Tests/UnitTests/MockRpcClient.cs
@@ -23,6 +23,7 @@ public class MockRpcClient : IRPCClient
 	public Func<uint256, bool, Task<Transaction>>? OnGetRawTransactionAsync { get; set; }
 	public Func<int, EstimateSmartFeeMode, Task<EstimateSmartFeeResponse>>? OnEstimateSmartFeeAsync { get; set; }
 	public Func<Task<PeerInfo[]>>? OnGetPeersInfoAsync { get; set; }
+	public Func<Task<int>>? OnGetConnectionCountAsync { get; set; }
 	public Func<int, BitcoinAddress, Task<uint256[]>>? OnGenerateToAddressAsync { get; set; }
 	public Func<Task<int>>? OnGetBlockCountAsync { get; set; }
 	public Func<Task<TimeSpan>>? OnUptimeAsync { get; set; }
@@ -90,6 +91,11 @@ public class MockRpcClient : IRPCClient
 	public Task<PeerInfo[]> GetPeersInfoAsync(CancellationToken cancellationToken = default)
 	{
 		return OnGetPeersInfoAsync?.Invoke() ?? NotImplementedTask<PeerInfo[]>(nameof(GetPeersInfoAsync));
+	}
+
+	public Task<int> GetConnectionCountAsync(CancellationToken cancellationToken = default)
+	{
+		return OnGetConnectionCountAsync?.Invoke() ?? NotImplementedTask<int>(nameof(GetConnectionCountAsync));
 	}
 
 	public Task<uint256[]> GetRawMempoolAsync(CancellationToken cancellationToken = default)

--- a/WalletWasabi/BitcoinCore/CoreNode.cs
+++ b/WalletWasabi/BitcoinCore/CoreNode.cs
@@ -280,7 +280,7 @@ public class CoreNode
 		// If it isn't already running, then we run it.
 		if (await coreNode.RpcClient.TestAsync(cancel).ConfigureAwait(false) is null)
 		{
-			Logger.LogInfo("A Bitcoin node is already running.");
+			await coreNode.LogAndValidateAlreadyRunningNodeAsync(cancel).ConfigureAwait(false);
 		}
 		else
 		{
@@ -293,6 +293,25 @@ public class CoreNode
 		await coreNode.P2pNode.ConnectAsync(cancel).ConfigureAwait(false);
 
 		return coreNode;
+	}
+
+	private async Task LogAndValidateAlreadyRunningNodeAsync(CancellationToken cancel)
+	{
+		BlockchainInfo blockchainInfo = await RpcClient.GetBlockchainInfoAsync(cancel).ConfigureAwait(false);
+		int connectionCount = await RpcClient.GetConnectionCountAsync(cancel).ConfigureAwait(false);
+
+		Logger.LogInfo(
+			$"A Bitcoin node is already running on RPC endpoint {RpcEndPoint}. " +
+			$"Chain={blockchainInfo.Chain}, Blocks={blockchainInfo.Blocks}, Headers={blockchainInfo.Headers}, " +
+			$"InitialBlockDownload={blockchainInfo.InitialBlockDownload}, VerificationProgress={blockchainInfo.VerificationProgress:P2}, " +
+			$"Peers={connectionCount}, DataDir={DataDir}, P2PEndpoint={P2pEndPoint}.");
+
+		if (blockchainInfo.Chain != Network)
+		{
+			throw new InvalidOperationException(
+				$"The Bitcoin node responding on RPC endpoint {RpcEndPoint} is on the {blockchainInfo.Chain} network, " +
+				$"but Ginger Wallet is configured for the {Network} network.");
+		}
 	}
 
 	private static EndPoint? GetConnectableBindEndPoint(EndPoint? bindEndPoint)

--- a/WalletWasabi/BitcoinCore/Monitoring/RpcMonitor.cs
+++ b/WalletWasabi/BitcoinCore/Monitoring/RpcMonitor.cs
@@ -12,7 +12,7 @@ public class RpcMonitor : PeriodicRunner
 
 	public RpcMonitor(TimeSpan period, IRPCClient rpcClient) : base(period)
 	{
-		_rpcStatus = RpcStatus.Unresponsive;
+		_rpcStatus = RpcStatus.Connecting;
 		RpcClient = rpcClient;
 	}
 

--- a/WalletWasabi/BitcoinCore/Monitoring/RpcStatus.cs
+++ b/WalletWasabi/BitcoinCore/Monitoring/RpcStatus.cs
@@ -36,7 +36,18 @@ public class RpcStatus : IEquatable<RpcStatus>
 		PeersCount = peersCount;
 	}
 
+	private RpcStatus(string status)
+	{
+		Status = status;
+		Success = false;
+		Headers = 0;
+		Blocks = 0;
+		PeersCount = 0;
+		Synchronized = false;
+	}
+
 	public static RpcStatus Unresponsive { get; } = new RpcStatus(false, 0, 0, 0);
+	public static RpcStatus Connecting { get; } = new RpcStatus(Resources.FullNodeConnecting);
 
 	public string Status { get; }
 	public bool Success { get; }
@@ -55,9 +66,17 @@ public class RpcStatus : IEquatable<RpcStatus>
 
 	public bool Equals(RpcStatus? other) => this == other;
 
-	public override int GetHashCode() => Status.GetHashCode();
+	public override int GetHashCode() => HashCode.Combine(Status, Success, Headers, Blocks, PeersCount, Synchronized);
 
-	public static bool operator ==(RpcStatus? x, RpcStatus? y) => y?.Status == x?.Status;
+	public static bool operator ==(RpcStatus? x, RpcStatus? y) =>
+		x is null ? y is null :
+		y is not null &&
+		x.Status == y.Status &&
+		x.Success == y.Success &&
+		x.Headers == y.Headers &&
+		x.Blocks == y.Blocks &&
+		x.PeersCount == y.PeersCount &&
+		x.Synchronized == y.Synchronized;
 
 	public static bool operator !=(RpcStatus? x, RpcStatus? y) => !(x == y);
 

--- a/WalletWasabi/BitcoinCore/Rpc/CachedRpcClient.cs
+++ b/WalletWasabi/BitcoinCore/Rpc/CachedRpcClient.cs
@@ -134,6 +134,17 @@ public class CachedRpcClient : RpcClientBase
 			cancellationToken).ConfigureAwait(false);
 	}
 
+	public override async Task<int> GetConnectionCountAsync(CancellationToken cancellationToken = default)
+	{
+		string cacheKey = nameof(GetConnectionCountAsync);
+
+		return await IdempotencyRequestCache.GetCachedResponseAsync(
+			cacheKey,
+			action: (string request, CancellationToken cancellationToken) => base.GetConnectionCountAsync(cancellationToken),
+			options: GetPeersInfoCacheOptions,
+			cancellationToken).ConfigureAwait(false);
+	}
+
 	public override async Task<MempoolEntry> GetMempoolEntryAsync(uint256 txid, bool throwIfNotFound = true, CancellationToken cancellationToken = default)
 	{
 		string cacheKey = $"{nameof(GetMempoolEntryAsync)}:{txid}";

--- a/WalletWasabi/BitcoinCore/Rpc/IRPCClient.cs
+++ b/WalletWasabi/BitcoinCore/Rpc/IRPCClient.cs
@@ -30,6 +30,8 @@ public interface IRPCClient
 
 	Task<PeerInfo[]> GetPeersInfoAsync(CancellationToken cancellationToken = default);
 
+	Task<int> GetConnectionCountAsync(CancellationToken cancellationToken = default);
+
 	Task<TimeSpan> UptimeAsync(CancellationToken cancellationToken = default);
 
 	Task<uint256> SendRawTransactionAsync(Transaction transaction, CancellationToken cancellationToken = default);

--- a/WalletWasabi/BitcoinCore/Rpc/RpcClientBase.cs
+++ b/WalletWasabi/BitcoinCore/Rpc/RpcClientBase.cs
@@ -59,6 +59,12 @@ public class RpcClientBase : IRPCClient
 		return await Rpc.GetPeersInfoAsync(cancellationToken).ConfigureAwait(false);
 	}
 
+	public virtual async Task<int> GetConnectionCountAsync(CancellationToken cancellationToken = default)
+	{
+		var response = await Rpc.SendCommandAsync(RPCOperations.getconnectioncount, cancellationToken).ConfigureAwait(false);
+		return response.Result.Value<int>();
+	}
+
 	public virtual async Task<MempoolEntry> GetMempoolEntryAsync(uint256 txid, bool throwIfNotFound = true, CancellationToken cancellationToken = default)
 	{
 		return await Rpc.GetMempoolEntryAsync(txid, throwIfNotFound, cancellationToken).ConfigureAwait(false);

--- a/WalletWasabi/Extensions/RPCClientExtensions.cs
+++ b/WalletWasabi/Extensions/RPCClientExtensions.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using WalletWasabi.Bases;
 using WalletWasabi.BitcoinCore.Monitoring;
 using WalletWasabi.BitcoinCore.Rpc;
 using WalletWasabi.Blockchain.Analysis.FeesEstimation;
@@ -16,6 +17,8 @@ namespace WalletWasabi.Extensions;
 public static class RPCClientExtensions
 {
 	private const EstimateSmartFeeMode EstimateMode = EstimateSmartFeeMode.Conservative;
+	private static readonly LastExceptionTracker RpcStatusExceptionTracker = new();
+	private static readonly object RpcStatusExceptionTrackerLock = new();
 
 	public static async Task<EstimateSmartFeeResponse> EstimateConservativeSmartFeeAsync(this IRPCClient rpc, int confirmationTarget, CancellationToken cancellationToken = default)
 	{
@@ -215,13 +218,30 @@ public static class RPCClientExtensions
 		try
 		{
 			var bci = await rpc.GetBlockchainInfoAsync(cancel).ConfigureAwait(false);
-			var pi = await rpc.GetPeersInfoAsync(cancel).ConfigureAwait(false);
+			var peersCount = await rpc.GetConnectionCountAsync(cancel).ConfigureAwait(false);
 
-			return RpcStatus.Responsive(bci.Headers, bci.Blocks, pi.Length);
+			lock (RpcStatusExceptionTrackerLock)
+			{
+				if (RpcStatusExceptionTracker.LastException is { } info)
+				{
+					Logger.LogInfo($"Bitcoin node RPC status check recovered after {(DateTimeOffset.UtcNow - info.FirstAppeared).TotalSeconds:F0} seconds and {info.ExceptionCount} failed attempt(s).");
+					RpcStatusExceptionTracker.Reset();
+				}
+			}
+
+			return RpcStatus.Responsive(bci.Headers, bci.Blocks, peersCount);
 		}
 		catch (Exception ex) when (ex is not OperationCanceledException and not TimeoutException)
 		{
-			Logger.LogTrace(ex);
+			lock (RpcStatusExceptionTrackerLock)
+			{
+				ExceptionInfo info = RpcStatusExceptionTracker.Process(ex);
+				if (info.IsFirst)
+				{
+					Logger.LogWarning($"Bitcoin node RPC status check failed: {ex.ToTypeMessageString()}");
+				}
+			}
+
 			return RpcStatus.Unresponsive;
 		}
 	}


### PR DESCRIPTION
## Summary

This PR improves local Bitcoin Core status reporting in the desktop client so startup, sync, and externally started node cases are easier to distinguish.

## Changes

- Add an explicit `Connecting` RPC status so the UI does not jump straight from startup into an unresponsive state.
- Include node peer count in RPC status evaluation, so a reachable node without peers can be reported more accurately.
- Improve first-failure and recovery logging around RPC status checks.
- Add diagnostics when Ginger detects an already-running Bitcoin Core process, including network/datadir mismatch handling.
- Keep the status converter fallback aligned with the new connecting state.

## Impact

Users should get a more accurate status while the local node is starting or syncing, and logs should make externally started or mismatched Bitcoin Core processes easier to diagnose instead of silently leaving the desktop in a misleading state.

## Validation

- `dotnet build WalletWasabi.Fluent.Desktop\WalletWasabi.Fluent.Desktop.csproj --no-restore`
- `dotnet build WalletWasabi.Tests\WalletWasabi.Tests.csproj --no-restore`
- `dotnet test WalletWasabi.Tests\WalletWasabi.Tests.csproj --filter "FullyQualifiedName~WalletWasabi.Tests.UnitTests" --logger "console;verbosity=normal"` - 954 passed
- Manual desktop software testing completed against the local Bitcoin Core status scenarios
