### PR TITLE
Move live exchange-rate tests out of unit suite

### DIFF
--- a/WalletWasabi.Tests/IntegrationTests/GingerCommonExchangeRateProviderTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/GingerCommonExchangeRateProviderTests.cs
@@ -1,0 +1,130 @@
+using GingerCommon.Providers.ExchangeRateProviders;
+using System.Threading;
+using System.Threading.Tasks;
+using WalletWasabi.Services;
+using WalletWasabi.Tests.Helpers;
+using WalletWasabi.Tor;
+using WalletWasabi.WebClients.Wasabi;
+using Xunit;
+
+namespace WalletWasabi.Tests.IntegrationTests;
+
+[Collection("Serial unit tests collection")]
+public class GingerCommonExchangeRateProviderTests : IAsyncLifetime
+{
+	private WasabiHttpClientFactory TorHttpClientFactory { get; }
+	private TorProcessManager TorProcessManager { get; }
+
+	public GingerCommonExchangeRateProviderTests()
+	{
+		TorProcessManager = new(Common.TorSettings);
+		TorHttpClientFactory = new(Common.TorSocks5Endpoint, backendUriGetter: null);
+	}
+
+	public async Task InitializeAsync()
+	{
+		using CancellationTokenSource startTimeoutCts = new(TimeSpan.FromMinutes(2));
+
+		await TorProcessManager.StartAsync(startTimeoutCts.Token);
+	}
+
+	public async Task DisposeAsync()
+	{
+		await TorHttpClientFactory.DisposeAsync();
+		await TorProcessManager.DisposeAsync();
+	}
+
+	private async Task TestProviderAsync(ExchangeRateProvider provider, bool tor = true, int waitTokenSec = 30, int currencyCount = 4)
+	{
+		var message = $"{provider.GetType().Name}, Tor: {tor}";
+		var endPoint = tor ? TorHttpClientFactory.TorEndpoint : null;
+
+		var refreshTime = TimeSpan.FromMinutes(15);
+
+		// Live provider tests tolerate transient external API failures.
+		const int MaxTries = 5;
+
+		ExchangeRate? resUSD = null;
+		for (int tryIdx = 0; tryIdx < MaxTries; tryIdx++)
+		{
+			using CancellationTokenSource cts = new(waitTokenSec * 1000);
+			resUSD = await provider.GetRateAsync("usd", refreshTime, endPoint, cts.Token);
+			if (resUSD is not null)
+			{
+				break;
+			}
+			if (provider.Currencies.Count == 0)
+			{
+				provider.ResetCurrencyUpdate();
+			}
+			await Task.Delay(10000);
+		}
+		Assert.True(resUSD is not null, message);
+
+		ExchangeRate? resEUR = null;
+		for (int tryIdx = 0; tryIdx < MaxTries; tryIdx++)
+		{
+			using CancellationTokenSource cts = new(waitTokenSec * 1000);
+			resEUR = await provider.GetRateAsync("EUR", refreshTime, endPoint, cts.Token);
+			if (resEUR is not null)
+			{
+				break;
+			}
+			await Task.Delay(10000);
+		}
+		Assert.True(resEUR is not null, message);
+
+		{
+			using CancellationTokenSource cts = new(waitTokenSec * 1000);
+			var curr = await provider.GetSupportedCurrenciesAsync(endPoint, cts.Token);
+			Assert.True(curr.Count >= currencyCount, message);
+		}
+	}
+
+	[Fact]
+	public async Task CoinGeckoExchangeRateProviderTestAsync()
+	{
+		// CoinGecko not able to support tor reliably for testing
+		await TestProviderAsync(new CoinGeckoExchangeRateProvider(), false);
+	}
+
+	[Fact]
+	public async Task CoinbaseExchangeRateProviderTestAsync()
+	{
+		// Tor: Just a moment...
+		await TestProviderAsync(new CoinbaseExchangeRateProvider());
+	}
+
+	[Fact]
+	public async Task GeminiExchangeRateProviderTestAsync()
+	{
+		await TestProviderAsync(new GeminiExchangeRateProvider());
+	}
+
+	[Fact]
+	public async Task CoinGateExchangeRateProviderTestAsync()
+	{
+		// Tor: Why have I been blocked?
+		await TestProviderAsync(new CoingateExchangeRateProvider());
+	}
+
+	[Fact]
+	public async Task BlockchainInfoExchangeRateProviderTestAsync()
+	{
+		var provider = new BlockchainInfoExchangeRateProvider();
+		await TestProviderAsync(provider);
+		Assert.Equal(ExchangeRateService.DefaultCurrencies, provider.Currencies);
+	}
+
+	[Fact]
+	public async Task MempoolSpaceExchangeRateProviderTestAsync()
+	{
+		await TestProviderAsync(new MempoolSpaceExchangeRateProvider());
+	}
+
+	[Fact]
+	public async Task AggregatorExchangeRateProviderTestAsync()
+	{
+		await TestProviderAsync(new AggregatorExchangeRateProvider(), false);
+	}
+}

--- a/WalletWasabi.Tests/UnitTests/StandaloneTests/ExchangeRateProviderTests.cs
+++ b/WalletWasabi.Tests/UnitTests/StandaloneTests/ExchangeRateProviderTests.cs
@@ -1,87 +1,11 @@
 using GingerCommon.Providers.ExchangeRateProviders;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-using WalletWasabi.Services;
-using WalletWasabi.Tests.Helpers;
-using WalletWasabi.Tor;
-using WalletWasabi.WebClients.Wasabi;
 using Xunit;
 
 namespace WalletWasabi.Tests.UnitTests.StandaloneTests;
 
-[Collection("Serial unit tests collection")]
-public class ExchangeRateProviderTests : IAsyncLifetime
+public class ExchangeRateProviderTests
 {
-	private WasabiHttpClientFactory TorHttpClientFactory { get; }
-	private TorProcessManager TorProcessManager { get; }
-
-	public ExchangeRateProviderTests()
-	{
-		TorProcessManager = new(Common.TorSettings);
-		TorHttpClientFactory = new(Common.TorSocks5Endpoint, backendUriGetter: null);
-	}
-
-	public async Task InitializeAsync()
-	{
-		using CancellationTokenSource startTimeoutCts = new(TimeSpan.FromMinutes(2));
-
-		await TorProcessManager.StartAsync(startTimeoutCts.Token);
-	}
-
-	public async Task DisposeAsync()
-	{
-		await TorHttpClientFactory.DisposeAsync();
-		await TorProcessManager.DisposeAsync();
-	}
-
-	private async Task TestProviderAsync(ExchangeRateProvider provider, bool tor = true, int waitTokenSec = 30, int currencyCount = 4)
-	{
-		var message = $"{provider.GetType().Name}, Tor: {tor}";
-		var endPoint = tor ? TorHttpClientFactory.TorEndpoint : null;
-
-		var refreshTime = TimeSpan.FromMinutes(15);
-
-		// Let's allow some failures
-		const int MaxTries = 5;
-
-		ExchangeRate? resUSD = null;
-		for (int tryIdx = 0; tryIdx < MaxTries; tryIdx++)
-		{
-			using CancellationTokenSource cts = new(waitTokenSec * 1000);
-			resUSD = await provider.GetRateAsync("usd", refreshTime, endPoint, cts.Token);
-			if (resUSD is not null)
-			{
-				break;
-			}
-			if (provider.Currencies.Count == 0)
-			{
-				provider.ResetCurrencyUpdate();
-			}
-			await Task.Delay(10000);
-		}
-		Assert.True(resUSD is not null, message);
-
-		ExchangeRate? resEUR = null;
-		for (int tryIdx = 0; tryIdx < MaxTries; tryIdx++)
-		{
-			using CancellationTokenSource cts = new(waitTokenSec * 1000);
-			resEUR = await provider.GetRateAsync("EUR", refreshTime, endPoint, cts.Token);
-			if (resEUR is not null)
-			{
-				break;
-			}
-			await Task.Delay(10000);
-		}
-		Assert.True(resEUR is not null, message);
-
-		{
-			using CancellationTokenSource cts = new(waitTokenSec * 1000);
-			var curr = await provider.GetSupportedCurrenciesAsync(endPoint, cts.Token);
-			Assert.True(curr.Count >= currencyCount, message);
-		}
-	}
-
 	[Fact]
 	private void ValidCurrencyTest()
 	{
@@ -95,52 +19,5 @@ public class ExchangeRateProviderTests : IAsyncLifetime
 		Assert.Contains("USD", ExchangeRateProvider.ValidCurrencies);
 		Assert.Contains("EUR", ExchangeRateProvider.ValidCurrencies);
 		Assert.Contains("HUF", ExchangeRateProvider.ValidCurrencies);
-	}
-
-	[Fact]
-	public async Task CoinGeckoExchangeRateProviderTestAsync()
-	{
-		// CoinGecko not able to support tor reliably for testing
-		await TestProviderAsync(new CoinGeckoExchangeRateProvider(), false);
-	}
-
-	[Fact]
-	public async Task CoinbaseExchangeRateProviderTestAsync()
-	{
-		// Tor: Just a moment...
-		await TestProviderAsync(new CoinbaseExchangeRateProvider());
-	}
-
-	[Fact]
-	public async Task GeminiExchangeRateProviderTestAsync()
-	{
-		await TestProviderAsync(new GeminiExchangeRateProvider());
-	}
-
-	[Fact]
-	public async Task CoinGateExchangeRateProviderTestAsync()
-	{
-		// Tor: Why have I been blocked?
-		await TestProviderAsync(new CoingateExchangeRateProvider());
-	}
-
-	[Fact]
-	public async Task BlockchainInfoExchangeRateProviderTestAsync()
-	{
-		var provider = new BlockchainInfoExchangeRateProvider();
-		await TestProviderAsync(provider);
-		Assert.Equal(ExchangeRateService.DefaultCurrencies, provider.Currencies);
-	}
-
-	[Fact]
-	public async Task MempoolSpaceExchangeRateProviderTestAsync()
-	{
-		await TestProviderAsync(new MempoolSpaceExchangeRateProvider());
-	}
-
-	[Fact]
-	public async Task AggregatorExchangeRateProviderTestAsync()
-	{
-		await TestProviderAsync(new AggregatorExchangeRateProvider(), false);
 	}
 }


### PR DESCRIPTION
## Summary

- Move live GingerCommon exchange-rate provider checks from the UnitTests namespace into IntegrationTests.
- Keep the deterministic currency-list assertion in the unit suite.
- Leave the live provider tests runnable locally by name, including the mempool.space Tor path.

## Why

The CI UnitTests workflow filters tests by `UnitTests`, so live external API checks in that namespace can fail the unit job when an upstream provider or Tor route is unavailable. Moving these tests to the integration/live test area keeps the checks available for local validation without causing false unit-test failures.

## Validation

- `dotnet test WalletWasabi.Tests\WalletWasabi.Tests.csproj --configuration Release --filter "ValidCurrencyTest" --logger "console;verbosity=minimal"`
- `dotnet test WalletWasabi.Tests\WalletWasabi.Tests.csproj --configuration Release --no-build --filter "MempoolSpaceExchangeRateProviderTestAsync" --logger "console;verbosity=minimal"`
- `dotnet test WalletWasabi.Tests\WalletWasabi.Tests.csproj --configuration Release --no-build --filter "UnitTests" --list-tests | Select-String -Pattern "MempoolSpaceExchangeRateProviderTestAsync|GingerCommonExchangeRateProviderTests|CoinbaseExchangeRateProviderTestAsync|AggregatorExchangeRateProviderTestAsync"` returned no matches.

Note: the first parallel attempt to run the moved mempool test hit a Windows build-output file lock because another `dotnet test` build was running at the same time; rerunning with `--no-build` passed.