### PR TITLE
Speed up WabiSabi unit tests

### DIFF
--- a/WalletWasabi.Tests/UnitTests/BlockNotifierTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BlockNotifierTests.cs
@@ -1,5 +1,5 @@
 using NBitcoin;
-using System.Globalization;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,23 +13,23 @@ namespace WalletWasabi.Tests.UnitTests;
 [Collection("Serial unit tests collection")]
 public class BlockNotifierTests
 {
+	private static readonly TimeSpan RoundTimeout = TimeSpan.FromSeconds(1);
+
 	[Fact]
 	public async Task GenesisBlockOnlyAsync()
 	{
 		var chain = new ConcurrentChain(Network.RegTest);
 		using var notifier = CreateNotifier(chain);
-		var blockAwaiter = new EventAwaiter<Block>(
-			h => notifier.OnBlock += h,
-			h => notifier.OnBlock -= h);
-		var reorgAwaiter = new EventAwaiter<uint256>(
-			h => notifier.OnReorg += h,
-			h => notifier.OnReorg -= h);
+		int blockCount = 0;
+		int reorgCount = 0;
+		notifier.OnBlock += (_, _) => blockCount++;
+		notifier.OnReorg += (_, _) => reorgCount++;
 
-		await notifier.StartAsync(CancellationToken.None);
+		await StartAndWaitRoundAsync(notifier);
 
 		// No block notifications nor reorg notifications
-		await Assert.ThrowsAsync<TimeoutException>(() => blockAwaiter.WaitAsync(TimeSpan.FromSeconds(1)));
-		await Assert.ThrowsAsync<TimeoutException>(() => reorgAwaiter.WaitAsync(TimeSpan.FromSeconds(1)));
+		Assert.Equal(0, blockCount);
+		Assert.Equal(0, reorgCount);
 
 		Assert.Equal(Network.RegTest.GenesisHash, notifier.BestBlockHash);
 
@@ -45,18 +45,16 @@ public class BlockNotifierTests
 			await AddBlockAsync(chain);
 		}
 		using var notifier = CreateNotifier(chain);
-		var blockAwaiter = new EventAwaiter<Block>(
-			h => notifier.OnBlock += h,
-			h => notifier.OnBlock -= h);
-		var reorgAwaiter = new EventAwaiter<uint256>(
-			h => notifier.OnReorg += h,
-			h => notifier.OnReorg -= h);
+		int blockCount = 0;
+		int reorgCount = 0;
+		notifier.OnBlock += (_, _) => blockCount++;
+		notifier.OnReorg += (_, _) => reorgCount++;
 
-		await notifier.StartAsync(CancellationToken.None);
+		await StartAndWaitRoundAsync(notifier);
 
 		// No block notifications nor reorg notifications
-		await Assert.ThrowsAsync<TimeoutException>(() => blockAwaiter.WaitAsync(TimeSpan.FromSeconds(1)));
-		await Assert.ThrowsAsync<TimeoutException>(() => reorgAwaiter.WaitAsync(TimeSpan.FromSeconds(1)));
+		Assert.Equal(0, blockCount);
+		Assert.Equal(0, reorgCount);
 
 		Assert.Equal(chain.Tip.HashBlock, notifier.BestBlockHash);
 
@@ -66,64 +64,35 @@ public class BlockNotifierTests
 	[Fact]
 	public async Task NotifyBlocksAsync()
 	{
-		using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1.5));
-
 		const int BlockCount = 3;
 		var chain = new ConcurrentChain(Network.RegTest);
 		using var notifier = CreateNotifier(chain);
 
-		var reorgAwaiter = new EventAwaiter<uint256>(
-			h => notifier.OnReorg += h,
-			h => notifier.OnReorg -= h);
+		var notifiedBlocks = new List<Block>();
+		int reorgCount = 0;
+		notifier.OnBlock += (_, block) => notifiedBlocks.Add(block);
+		notifier.OnReorg += (_, _) => reorgCount++;
 
-		await notifier.StartAsync(CancellationToken.None);
-
-		// Assert that the blocks come in the right order
-		var height = 0;
-		string message = string.Empty;
-
-		void OnBlockInv(object? blockNotifier, Block b)
-		{
-			uint256 h1 = b.GetHash();
-			uint256 h2 = chain.GetBlock(height + 1).HashBlock;
-
-			if (h1 != h2)
-			{
-				message = string.Format(CultureInfo.InvariantCulture, "height={0}, [h1] {1} != [h2] {2}", height, h1, h2);
-				cts.Cancel();
-				return;
-			}
-
-			height++;
-
-			if (height == BlockCount)
-			{
-				cts.Cancel();
-			}
-		}
-
-		notifier.OnBlock += OnBlockInv;
+		await StartAndWaitRoundAsync(notifier);
 
 		foreach (var n in Enumerable.Range(0, BlockCount))
 		{
 			await AddBlockAsync(chain);
 		}
 
-		notifier.TriggerRound();
-
-		// Waits at most 1.5s given CancellationTokenSource definition
-		await Task.WhenAny(Task.Delay(Timeout.InfiniteTimeSpan, cts.Token));
-
-		Assert.True(string.IsNullOrEmpty(message), message);
+		await TriggerAndWaitRoundAsync(notifier);
 
 		// Three blocks notifications
-		Assert.Equal(chain.Height, height);
+		Assert.Equal(BlockCount, notifiedBlocks.Count);
+		for (int i = 0; i < notifiedBlocks.Count; i++)
+		{
+			Assert.Equal(chain.GetBlock(i + 1).HashBlock, notifiedBlocks[i].GetHash());
+		}
 
 		// No reorg notifications
-		await Assert.ThrowsAsync<TimeoutException>(() => reorgAwaiter.WaitAsync(TimeSpan.FromSeconds(1)));
+		Assert.Equal(0, reorgCount);
 		Assert.Equal(chain.Tip.HashBlock, notifier.BestBlockHash);
 
-		notifier.OnBlock -= OnBlockInv;
 		await notifier.StopAsync(CancellationToken.None);
 	}
 
@@ -133,33 +102,29 @@ public class BlockNotifierTests
 		var chain = new ConcurrentChain(Network.RegTest);
 		using var notifier = CreateNotifier(chain);
 
-		var blockAwaiter = new EventsAwaiter<Block>(
-			h => notifier.OnBlock += h,
-			h => notifier.OnBlock -= h,
-			5);
+		var notifiedBlocks = new List<Block>();
+		var reorgedBlocks = new List<uint256>();
+		notifier.OnBlock += (_, block) => notifiedBlocks.Add(block);
+		notifier.OnReorg += (_, blockHash) => reorgedBlocks.Add(blockHash);
 
-		var reorgAwaiter = new EventAwaiter<uint256>(
-			h => notifier.OnReorg += h,
-			h => notifier.OnReorg -= h);
-
-		await notifier.StartAsync(CancellationToken.None);
+		await StartAndWaitRoundAsync(notifier);
 
 		await AddBlockAsync(chain);
+		await TriggerAndWaitRoundAsync(notifier);
 		var forkPoint = chain.Tip;
 		var blockToBeReorged = await AddBlockAsync(chain);
+		await TriggerAndWaitRoundAsync(notifier);
 
 		chain.SetTip(forkPoint);
 		await AddBlockAsync(chain, wait: false);
 		await AddBlockAsync(chain, wait: false);
 		await AddBlockAsync(chain);
-		notifier.TriggerRound();
+		await TriggerAndWaitRoundAsync(notifier);
 
-		// Three blocks notifications
-		await blockAwaiter.WaitAsync(TimeSpan.FromSeconds(2));
+		Assert.Equal(5, notifiedBlocks.Count);
 
-		// No reorg notifications
-		var reorgedkBlock = await reorgAwaiter.WaitAsync(TimeSpan.FromSeconds(1));
-		Assert.Equal(blockToBeReorged.HashBlock, reorgedkBlock);
+		var reorgedBlock = Assert.Single(reorgedBlocks);
+		Assert.Equal(blockToBeReorged.HashBlock, reorgedBlock);
 		Assert.Equal(chain.Tip.HashBlock, notifier.BestBlockHash);
 
 		await notifier.StopAsync(CancellationToken.None);
@@ -171,19 +136,15 @@ public class BlockNotifierTests
 		var chain = new ConcurrentChain(Network.RegTest);
 		using var notifier = CreateNotifier(chain);
 
-		var blockAwaiter = new EventsAwaiter<Block>(
-			h => notifier.OnBlock += h,
-			h => notifier.OnBlock -= h,
-			11);
+		var notifiedBlocks = new List<Block>();
+		var reorgedBlocks = new List<uint256>();
+		notifier.OnBlock += (_, block) => notifiedBlocks.Add(block);
+		notifier.OnReorg += (_, blockHash) => reorgedBlocks.Add(blockHash);
 
-		var reorgAwaiter = new EventsAwaiter<uint256>(
-			h => notifier.OnReorg += h,
-			h => notifier.OnReorg -= h,
-			3);
-
-		await notifier.StartAsync(CancellationToken.None);
+		await StartAndWaitRoundAsync(notifier);
 
 		await AddBlockAsync(chain);
+		await TriggerAndWaitRoundAsync(notifier);
 
 		var forkPoint = chain.Tip;
 		var firstReorgedChain = new[]
@@ -191,6 +152,7 @@ public class BlockNotifierTests
 				await AddBlockAsync(chain, wait: false),
 				await AddBlockAsync(chain)
 			};
+		await TriggerAndWaitRoundAsync(notifier);
 
 		chain.SetTip(forkPoint);
 		var secondReorgedChain = new[]
@@ -199,6 +161,7 @@ public class BlockNotifierTests
 				await AddBlockAsync(chain, wait: false),
 				await AddBlockAsync(chain)
 			};
+		await TriggerAndWaitRoundAsync(notifier);
 
 		chain.SetTip(secondReorgedChain[1]);
 		await AddBlockAsync(chain, wait: false);
@@ -206,14 +169,13 @@ public class BlockNotifierTests
 		await AddBlockAsync(chain, wait: false);
 		await AddBlockAsync(chain, wait: false);
 		await AddBlockAsync(chain);
+		await TriggerAndWaitRoundAsync(notifier);
 
-		// Three blocks notifications
-		await blockAwaiter.WaitAsync(TimeSpan.FromSeconds(2));
+		Assert.Equal(11, notifiedBlocks.Count);
 
-		// No reorg notifications
-		var reorgedkBlock = await reorgAwaiter.WaitAsync(TimeSpan.FromSeconds(1));
+		Assert.Equal(3, reorgedBlocks.Count);
 		var expectedReorgedBlocks = firstReorgedChain.ToList().Concat(new[] { secondReorgedChain[2] });
-		Assert.Subset(reorgedkBlock.ToHashSet(), expectedReorgedBlocks.Select(x => x.Header.GetHash()).ToHashSet());
+		Assert.Subset(reorgedBlocks.ToHashSet(), expectedReorgedBlocks.Select(x => x.Header.GetHash()).ToHashSet());
 		Assert.Equal(chain.Tip.HashBlock, notifier.BestBlockHash);
 
 		await notifier.StopAsync(CancellationToken.None);
@@ -229,20 +191,21 @@ public class BlockNotifierTests
 			h => notifier.OnBlock -= h,
 			144);
 
-		await notifier.StartAsync(CancellationToken.None);
+		await StartAndWaitRoundAsync(notifier);
 
-		var lastKnownBlock = await AddBlockAsync(chain);
+		await AddBlockAsync(chain);
+		await TriggerAndWaitRoundAsync(notifier);
 
 		foreach (var i in Enumerable.Range(0, 200))
 		{
 			await AddBlockAsync(chain, wait: false);
 		}
 		await AddBlockAsync(chain, wait: true);
-		notifier.TriggerRound();
+		await TriggerAndWaitRoundAsync(notifier);
 
 		Assert.Equal(chain.Tip.HashBlock, notifier.BestBlockHash);
 
-		var nofifiedBlocks = (await blockAwaiter.WaitAsync(TimeSpan.FromSeconds(1))).ToArray();
+		var nofifiedBlocks = (await blockAwaiter.WaitAsync(RoundTimeout)).ToArray();
 
 		var tip = chain.Tip;
 		var pos = nofifiedBlocks.Length - 1;
@@ -274,8 +237,19 @@ public class BlockNotifierTests
 
 		rpc.OnGetBlockHeaderAsync = (blockHash) => Task.FromResult(chain.GetBlock(blockHash).Header);
 
-		var notifier = new BlockNotifier(TimeSpan.FromMilliseconds(100), rpc);
+		var notifier = new BlockNotifier(TimeSpan.FromHours(1), rpc);
 		return notifier;
+	}
+
+	private static async Task StartAndWaitRoundAsync(BlockNotifier notifier)
+	{
+		await notifier.StartAsync(CancellationToken.None);
+		await TriggerAndWaitRoundAsync(notifier);
+	}
+
+	private static async Task TriggerAndWaitRoundAsync(BlockNotifier notifier)
+	{
+		await notifier.TriggerAndWaitRoundAsync(RoundTimeout);
 	}
 
 	private async Task<ChainedBlock> AddBlockAsync(ConcurrentChain chain, bool wait = true)
@@ -287,7 +261,7 @@ public class BlockNotifierTests
 		var block = chain.GetBlock(header.GetHash());
 		if (wait)
 		{
-			await Task.Delay(TimeSpan.FromSeconds(1));
+			await Task.Yield();
 		}
 		return block;
 	}

--- a/WalletWasabi.Tests/UnitTests/SafeIoManagerTests.cs
+++ b/WalletWasabi.Tests/UnitTests/SafeIoManagerTests.cs
@@ -65,8 +65,8 @@ public class SafeIoManagerTests
 		Assert.True(IsStringArraysEqual(readLines, lines.ToArray()));
 
 		// Write the same content, file should be rewritten.
-		var currentDate = File.GetLastWriteTimeUtc(ioman1.FilePath);
-		await Task.Delay(500);
+		var currentDate = File.GetLastWriteTimeUtc(ioman1.FilePath) - TimeSpan.FromMinutes(1);
+		File.SetLastWriteTimeUtc(ioman1.FilePath, currentDate);
 		await ioman1.WriteAllLinesAsync(lines);
 		var noChangeDate = File.GetLastWriteTimeUtc(ioman1.FilePath);
 		Assert.NotEqual(currentDate, noChangeDate);
@@ -160,7 +160,7 @@ public class SafeIoManagerTests
 			}
 		}
 
-		const int Iterations = 200;
+		const int Iterations = 75;
 
 		var t1 = new Thread(() =>
 		{

--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionFactoryTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionFactoryTests.cs
@@ -632,7 +632,8 @@ public class TransactionFactoryTests
 		Money paymentAmount = Money.Coins(0.29943925m);
 
 		using Key key = new();
-		TransactionFactory transactionFactory = ServiceFactory.CreateTransactionFactory(TestRandom.Get(), DemoCoinSets.LotOfCoins);
+		// The prefix is enough to exceed the target amount while still requiring too many inputs.
+		TransactionFactory transactionFactory = ServiceFactory.CreateTransactionFactory(TestRandom.Get(), DemoCoinSets.LotOfCoins.Take(2601));
 
 		PaymentIntent payment = new(key, MoneyRequest.Create(paymentAmount));
 		Assert.Equal(ChangeStrategy.Auto, payment.ChangeStrategy);
@@ -640,7 +641,7 @@ public class TransactionFactoryTests
 		var txParameters = CreateBuilder().SetPayment(payment).SetFeeRate(12m).Build();
 		TransactionSizeException ex = Assert.Throws<TransactionSizeException>(() => transactionFactory.BuildTransaction(txParameters));
 		Assert.Equal(paymentAmount, ex.Target);
-		Assert.Equal(Money.Coins(0.24209089m), ex.MaximumPossible);
+		Assert.Equal(Money.Coins(0.22127989m), ex.MaximumPossible);
 	}
 
 	[Fact]

--- a/WalletWasabi.Tests/UnitTests/UserInterfaceTest/PocketSelectionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/UserInterfaceTest/PocketSelectionTests.cs
@@ -17,14 +17,15 @@ namespace WalletWasabi.Tests.UnitTests.UserInterfaceTest;
 
 public class PocketSelectionTests
 {
+	private const string Password = "";
+	private static readonly KeyManager TestKeyManager = KeyManager.Recover(
+		new Mnemonic("all all all all all all all all all all all all"),
+		Password,
+		Network.Main,
+		KeyManager.GetAccountKeyPath(Network.Main, ScriptPubKeyType.Segwit));
+
 	private LabelSelectionViewModel CreateLabelSelectionViewModel(Money amount, LabelsArray recipient)
 	{
-		var pw = "";
-		var km = KeyManager.Recover(
-			new Mnemonic("all all all all all all all all all all all all"),
-			pw,
-			Network.Main,
-			KeyManager.GetAccountKeyPath(Network.Main, ScriptPubKeyType.Segwit));
 		var address = BitcoinAddress.Create("bc1q7v7qfhwx55erxkc66nsv39x4azwufvy6zq8ya4", Network.Main);
 		var info = new TransactionInfo(address, 100)
 		{
@@ -33,7 +34,7 @@ public class PocketSelectionTests
 			Recipient = recipient
 		};
 
-		return new LabelSelectionViewModel(km, pw, info, isSilent: false);
+		return new LabelSelectionViewModel(TestKeyManager, Password, info, isSilent: false);
 	}
 
 	[Fact]

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/AliceTimeoutTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/AliceTimeoutTests.cs
@@ -35,14 +35,14 @@ public class AliceTimeoutTests
 		using Arena arena = await ArenaTestFactory.From(cfg).With(rpc).CreateAndStartAsync(rnd, round);
 		var arenaClient = WabiSabiTestFactory.CreateArenaClient(arena);
 
-		using RoundStateUpdater roundStateUpdater = new(TimeSpan.FromSeconds(2), ["CoinJoinCoordinatorIdentifier"], arena);
+		using RoundStateUpdater roundStateUpdater = new(TimeSpan.FromMilliseconds(100), ["CoinJoinCoordinatorIdentifier"], arena, false);
 		await roundStateUpdater.StartAsync(testDeadlineCts.Token);
 
 		// Register Alices.
 		KeyChain keyChain = new(km, new Kitchen(ingredients: ""));
 
 		using CancellationTokenSource registrationCts = new();
-		Task<AliceClient> task = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round), arenaClient, smartCoin, keyChain, roundStateUpdater, registrationCts.Token, registrationCts.Token, confirmationCancellationToken: testDeadlineCts.Token, silentLeaveToken);
+		Task<AliceClient> task = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round), arenaClient, smartCoin, keyChain, roundStateUpdater, registrationCts.Token, registrationCts.Token, confirmationCancellationToken: registrationCts.Token, silentLeaveToken);
 
 		while (round.Alices.Count == 0)
 		{

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepOutputRegistrationTests.cs
@@ -222,7 +222,7 @@ public class StepOutputRegistrationTests
 		// Refresh the Arena States because of vsize manipulation.
 		await arena.TriggerAndWaitRoundAsync(token);
 
-		using RoundStateUpdater roundStateUpdater = new(TimeSpan.FromSeconds(2), ["CoinJoinCoordinatorIdentifier"], arena);
+		using RoundStateUpdater roundStateUpdater = new(TimeSpan.FromMilliseconds(100), ["CoinJoinCoordinatorIdentifier"], arena, false);
 		await roundStateUpdater.StartAsync(token);
 		var task1 = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round), arenaClient, coin1, keyChain, roundStateUpdater, token, token, token, silentLeaveToken);
 		var task2 = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round), arenaClient, coin2, keyChain, roundStateUpdater, token, token, token, silentLeaveToken);
@@ -284,7 +284,7 @@ public class StepOutputRegistrationTests
 		// Refresh the Arena States because of vsize manipulation.
 		await arena.TriggerAndWaitRoundAsync(token);
 
-		using RoundStateUpdater roundStateUpdater = new(TimeSpan.FromSeconds(2), ["CoinJoinCoordinatorIdentifier"], arena);
+		using RoundStateUpdater roundStateUpdater = new(TimeSpan.FromMilliseconds(100), ["CoinJoinCoordinatorIdentifier"], arena, false);
 		await roundStateUpdater.StartAsync(token);
 		var task1a = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round1), arenaClient1, coin1a, keyChain1, roundStateUpdater, token, token, token, silentLeaveToken);
 		var task1b = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round1), arenaClient1, coin1b, keyChain1, roundStateUpdater, token, token, token, silentLeaveToken);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
@@ -290,7 +290,7 @@ public class StepTransactionSigningTests
 		var arenaClient = WabiSabiTestFactory.CreateArenaClient(arena);
 
 		// Register Alices.
-		using RoundStateUpdater roundStateUpdater = new(TimeSpan.FromSeconds(2), ["CoinJoinCoordinatorIdentifier"], arena);
+		using RoundStateUpdater roundStateUpdater = new(TimeSpan.FromMilliseconds(100), ["CoinJoinCoordinatorIdentifier"], arena, false);
 		await roundStateUpdater.StartAsync(token);
 
 		var task1 = AliceClient.CreateRegisterAndConfirmInputAsync(RoundState.FromRound(round), arenaClient, coin1, keyChain, roundStateUpdater, token, token, token, silentLeaveToken);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/WhitelistTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/WhitelistTests.cs
@@ -1,5 +1,4 @@
 using System.Linq;
-using System.Threading.Tasks;
 using WalletWasabi.Tests.Helpers;
 using WalletWasabi.Tests.TestCommon;
 using WalletWasabi.WabiSabi.Backend.Banning;
@@ -10,11 +9,11 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend;
 public class WhitelistTests
 {
 	[Fact]
-	public async Task WhitelistChangeTrafficAsync()
+	public void WhitelistChangeTrafficAsync()
 	{
 		var rnd = TestRandom.Get();
 		var cfg = WabiSabiTestFactory.CreateDefaultWabiSabiConfig();
-		cfg.ReleaseFromWhitelistAfter = TimeSpan.FromSeconds(1);
+		cfg.ReleaseFromWhitelistAfter = TimeSpan.Zero;
 
 		Whitelist whitelist = new(Enumerable.Empty<Innocent>(), string.Empty, cfg);
 		var currentChangeId = whitelist.ChangeId;
@@ -36,7 +35,6 @@ public class WhitelistTests
 		whitelist.Add(outpoint3);
 		Assert.NotEqual(currentChangeId, whitelist.ChangeId);
 
-		await Task.Delay(1000);
 		whitelist.RemoveAllExpired();
 
 		Assert.Equal(0, whitelist.CountInnocents());

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/CoinJoinCoinSelectionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/CoinJoinCoinSelectionTests.cs
@@ -243,9 +243,21 @@ public class CoinJoinCoinSelectionTests
 		const int AnonymitySet = 10;
 		var km = KeyManager.CreateNew(out _, "", Network.Main);
 		SmartCoin smallerAnonCoin = BitcoinFactory.CreateSmartCoin(rnd, BitcoinFactory.CreateHdPubKey(km), Money.Coins(1m), anonymitySet: AnonymitySet - 1);
-		var coinsToSelectFrom = Enumerable
+		var privateCoins = Enumerable
 			.Range(0, 10)
 			.Select(i => BitcoinFactory.CreateSmartCoin(rnd, BitcoinFactory.CreateHdPubKey(km), Money.Coins(1m), anonymitySet: AnonymitySet + 1))
+			.ToList();
+
+		// Keep the background coins actually private so the only non-private coin is deterministic.
+		foreach (var coin in privateCoins)
+		{
+			var parent = BitcoinFactory.CreateSmartCoin(rnd, BitcoinFactory.CreateHdPubKey(km, isInternal: true), Money.Coins(1m), anonymitySet: AnonymitySet + 1);
+			parent.Transaction.TryAddWalletInput(BitcoinFactory.CreateSmartCoin(rnd, BitcoinFactory.CreateHdPubKey(km, isInternal: true), Money.Coins(1m), anonymitySet: AnonymitySet + 1));
+			coin.Transaction.TryAddWalletInput(parent);
+			BlockchainAnalyzer.SetIsSufficientlyDistancedFromExternalKeys(coin);
+		}
+
+		var coinsToSelectFrom = privateCoins
 			.Prepend(smallerAnonCoin)
 			.ToList();
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/CredentialDependencyTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/CredentialDependencyTests.cs
@@ -58,7 +58,7 @@ public class CredentialDependencyTests
 			Assert.DoesNotContain(node, sent);
 			sent.Add(node);
 
-			await Task.Delay(1 + Random.Shared.Next(10));
+			await Task.Yield();
 
 			return requested;
 		}

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/Participant.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/Participant.cs
@@ -74,7 +74,7 @@ internal class Participant
 		}
 
 		var apiClient = new WabiSabiHttpApiClient(HttpClientFactory.NewHttpClientWithDefaultCircuit());
-		using var roundStateUpdater = new RoundStateUpdater(TimeSpan.FromSeconds(3), ["CoinJoinCoordinatorIdentifier"], apiClient);
+		using var roundStateUpdater = new RoundStateUpdater(WabiSabiIntegrationTestConstants.RequestInterval, ["CoinJoinCoordinatorIdentifier"], apiClient, false);
 		await roundStateUpdater.StartAsync(cancellationToken).ConfigureAwait(false);
 
 		var outputProvider = new OutputProvider(Wallet);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiApiApplicationFactory.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiApiApplicationFactory.cs
@@ -61,7 +61,7 @@ public class WabiSabiApiApplicationFactory<TStartup> : WebApplicationFactory<TSt
 			services.AddScoped<Prison>(_ => WabiSabiTestFactory.CreatePrison());
 			services.AddScoped(services => CreateConfig(10));
 			services.AddScoped<RoundParameterFactory>();
-			services.AddScoped(typeof(TimeSpan), _ => TimeSpan.FromSeconds(2));
+			services.AddScoped(typeof(TimeSpan), _ => WabiSabiIntegrationTestConstants.RequestInterval);
 			services.AddScoped<ICoinJoinIdStore>(s => new CoinJoinIdStore());
 			services.AddScoped(s => new CoinJoinScriptStore());
 			services.AddSingleton<CoinJoinFeeRateStatStore>();
@@ -76,11 +76,13 @@ public class WabiSabiApiApplicationFactory<TStartup> : WebApplicationFactory<TSt
 	{
 		WabiSabiConfig config = WabiSabiBackendFactory.Instance.CreateWabiSabiConfig();
 		config.MaxInputCountByRound = maxIputCount;
-		config.StandardInputRegistrationTimeout = TimeSpan.FromSeconds(40);
-		config.BlameInputRegistrationTimeout = TimeSpan.FromSeconds(40);
-		config.ConnectionConfirmationTimeout = TimeSpan.FromSeconds(40);
-		config.OutputRegistrationTimeout = TimeSpan.FromSeconds(40);
-		config.TransactionSigningTimeout = TimeSpan.FromSeconds(40);
+		config.StandardInputRegistrationTimeout = WabiSabiIntegrationTestConstants.PhaseTimeout;
+		config.BlameInputRegistrationTimeout = WabiSabiIntegrationTestConstants.PhaseTimeout;
+		config.ConnectionConfirmationTimeout = WabiSabiIntegrationTestConstants.PhaseTimeout;
+		config.OutputRegistrationTimeout = WabiSabiIntegrationTestConstants.PhaseTimeout;
+		config.TransactionSigningTimeout = WabiSabiIntegrationTestConstants.PhaseTimeout;
+		config.FailFastOutputRegistrationTimeout = WabiSabiIntegrationTestConstants.PhaseTimeout;
+		config.FailFastTransactionSigningTimeout = WabiSabiIntegrationTestConstants.PhaseTimeout;
 		config.MaxSuggestedAmountBase = Money.Satoshis(ProtocolConstants.MaxAmountCredentialValue);
 		config.CreateNewRoundBeforeInputRegEnd = TimeSpan.Zero;
 		return config;
@@ -106,4 +108,10 @@ public class WabiSabiApiApplicationFactory<TStartup> : WebApplicationFactory<TSt
 
 	public WabiSabiHttpApiClient CreateWabiSabiHttpApiClient(HttpClient httpClient) =>
 		new(new ClearnetHttpClient(httpClient));
+}
+
+internal static class WabiSabiIntegrationTestConstants
+{
+	public static readonly TimeSpan RequestInterval = TimeSpan.FromMilliseconds(100);
+	public static readonly TimeSpan PhaseTimeout = TimeSpan.FromSeconds(5);
 }

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/WabiSabiHttpApiIntegrationTests.cs
@@ -146,7 +146,18 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 			{
 				// Instruct the coordinator DI container to use these two scoped
 				// services to build everything (WabiSabi controller, arena, etc)
-				services.AddScoped(s => WabiSabiApiApplicationFactory<Startup>.CreateConfig(inputCount - 1)); // Make sure that at least one IR fails for WrongPhase
+				services.AddScoped(s =>
+				{
+					WabiSabiConfig config = WabiSabiApiApplicationFactory<Startup>.CreateConfig(inputCount - 1); // Make sure that at least one IR fails for WrongPhase
+					config.StandardInputRegistrationTimeout = TimeSpan.FromSeconds(40);
+					config.BlameInputRegistrationTimeout = TimeSpan.FromSeconds(40);
+					config.ConnectionConfirmationTimeout = TimeSpan.FromSeconds(40);
+					config.OutputRegistrationTimeout = TimeSpan.FromSeconds(40);
+					config.TransactionSigningTimeout = TimeSpan.FromSeconds(40);
+					config.FailFastOutputRegistrationTimeout = TimeSpan.FromMinutes(3);
+					config.FailFastTransactionSigningTimeout = TimeSpan.FromMinutes(1);
+					return config;
+				});
 
 				// Emulate that the first coin is coming from a coinjoin.
 				services.AddScoped(s => new InMemoryCoinJoinIdStore(new[] { coins[0].Coin.Outpoint.Hash }));
@@ -166,7 +177,7 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 		using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(200));
 		cts.Token.Register(() => transactionCompleted.TrySetCanceled(), useSynchronizationContext: false);
 
-		using var roundStateUpdater = new RoundStateUpdater(TimeSpan.FromSeconds(1), ["CoinJoinCoordinatorIdentifier"], apiClient);
+		using var roundStateUpdater = new RoundStateUpdater(WabiSabiIntegrationTestConstants.RequestInterval, ["CoinJoinCoordinatorIdentifier"], apiClient, false);
 
 		await roundStateUpdater.StartAsync(CancellationToken.None);
 
@@ -231,7 +242,7 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 		using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(200));
 		cts.Token.Register(() => transactionCompleted.TrySetCanceled(), useSynchronizationContext: false);
 
-		using var roundStateUpdater = new RoundStateUpdater(TimeSpan.FromSeconds(1), ["CoinJoinCoordinatorIdentifier"], apiClient);
+		using var roundStateUpdater = new RoundStateUpdater(WabiSabiIntegrationTestConstants.RequestInterval, ["CoinJoinCoordinatorIdentifier"], apiClient, false);
 
 		await roundStateUpdater.StartAsync(CancellationToken.None);
 
@@ -322,8 +333,13 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 				WabiSabiConfig config = WabiSabiApiApplicationFactory<Startup>.CreateConfig(2 * inputCount);
 				config.AllowP2trInputs = true;
 				config.AllowP2trOutputs = true;
-				config.TransactionSigningTimeout = TimeSpan.FromSeconds(5 * inputCount);
-				config.BlameInputRegistrationTimeout = TimeSpan.FromSeconds(5 * inputCount);
+				config.StandardInputRegistrationTimeout = TimeSpan.FromSeconds(40);
+				config.ConnectionConfirmationTimeout = TimeSpan.FromSeconds(40);
+				config.OutputRegistrationTimeout = TimeSpan.FromSeconds(40);
+				config.TransactionSigningTimeout = TimeSpan.FromSeconds(20);
+				config.BlameInputRegistrationTimeout = TimeSpan.FromSeconds(20);
+				config.FailFastOutputRegistrationTimeout = TimeSpan.FromMinutes(3);
+				config.FailFastTransactionSigningTimeout = TimeSpan.FromMinutes(1);
 				return config;
 			}))).CreateClient();
 
@@ -354,7 +370,7 @@ public class WabiSabiHttpApiIntegrationTests : IClassFixture<WabiSabiApiApplicat
 		mockNonSigningHttpClientFactory.OnNewHttpClientWithPersonCircuit = () => (personCircuit, nonSigningHttpClient);
 		mockNonSigningHttpClientFactory.OnNewHttpClientWithCircuitPerRequest = () => nonSigningHttpClient;
 
-		using var roundStateUpdater = new RoundStateUpdater(TimeSpan.FromSeconds(1), [], apiClient, false);
+		using var roundStateUpdater = new RoundStateUpdater(WabiSabiIntegrationTestConstants.RequestInterval, [], apiClient, false);
 		await roundStateUpdater.StartAsync(CancellationToken.None);
 
 		var roundState = await roundStateUpdater.CreateRoundAwaiterAsync(roundState => roundState.Phase == Phase.InputRegistration, cts.Token);


### PR DESCRIPTION
## Summary
- reduce WabiSabi test polling intervals in HTTP integration and phase-stepping helpers
- shorten WabiSabi integration test phase timeouts where the scenario does not depend on long production-like waits
- keep longer phase windows for the coinjoin scenarios that need them for CI stability
- cancel the Alice timeout test's confirmation wait after the backend timeout assertion has been made
- remove fixed waits from SafeIo/Whitelist tests and trim the oversized TooManyInputCoins fixture while preserving the transaction-size exception case
- replace BlockNotifierTests wall-clock sleeps/timeout assertions with deterministic TriggerAndWaitRoundAsync checks
- reuse the deterministic PocketSelectionTests KeyManager instead of recovering it for every test
- replace simulated CredentialDependencyTests millisecond sleeps with Task.Yield while preserving async traversal
- stabilize the coin-selection consolidation fixture so the intended single non-private coin is deterministic

## Targeted Improvements
- BlockNotifierTests: 6 tests from ~20-21s targeted test duration to ~37ms
- PocketSelectionTests: 38 tests from ~5s targeted test duration to ~0.8s
- CredentialDependencyTests: 75 tests from ~3s targeted test duration to ~0.2s

## Validation
- `dotnet test WalletWasabi.Tests\WalletWasabi.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~WalletWasabi.Tests.UnitTests" --logger "trx;LogFileName=unit-only-after-coinselection-fix.trx" --results-directory TestResults\Overnight --verbosity quiet`
- Passed: 960, Failed: 0, Duration: 4m 55s
- Targeted reruns passed for BlockNotifierTests, PocketSelectionTests, CredentialDependencyTests
- CoinJoinCoinSelection consolidation fixture passed 11/11 targeted runs after stabilizing the private background coins
- Previous refreshed CI had linux-x64, osx-arm64, and osx-x64 passing; win-x64 exposed the coin-selection fixture flake and is being rerun after this fix