### PR TITLE
Sign Windows binaries before MSI packaging

### DIFF
--- a/WalletWasabi.Documentation/ClientRelease/ClientDeployment.md
+++ b/WalletWasabi.Documentation/ClientRelease/ClientDeployment.md
@@ -34,6 +34,10 @@ Make sure to run a virus detection scan on one of the Release candidate's .msi i
 - Run the [script file](https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi.Packager/scripts/Wasabi_release.ps1) on the **Windows Release Laptop** and follow the instructions.
 - At some point you will need to run [this script](https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi.Packager/scripts/WasabiNoratize.scpt) file on Mac. Don't forget to open the script file on Mac and insert your Apple dev username and password. Guide how to setup it: [macOS release environment](https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi.Documentation/Guides/MacOsSigning.md).
 - Finish the script on Windows. Now a folder should pop up with all the files that need to be uploaded to GitHub.
+- Verify the Windows Authenticode signatures before uploading:
+  - `signtool.exe verify /pa /v Ginger-<version>.msi`
+  - `signtool.exe verify /pa /v win-x64\wassabee.exe`
+  - `signtool.exe verify /pa /v win-x64\wassabeed.exe`
 - Test asc file for `.msi`.
 - Final `.msi` test on own computer. Check the About dialog and optionally the BUILDINFO.json next to the wasabi executable, the commit ID should match with the one on GitHub. 
 
@@ -80,6 +84,14 @@ Digicert holds our Code Signing Certificate under the name "zkSNACKs Limited".
 - Type: Code Signing
 - CSR Key Size: 3072
 
+The release script signs the Windows application executables before the MSI is built, then signs the final MSI after WiX finishes. By default it uses the thumbprint compiled into the packager, but the release machine can override it without code changes:
+
+```
+setx GINGER_WINDOWS_SIGN_CERT_SHA1 <certificate-thumbprint>
+```
+
+SmartScreen reputation is controlled by Microsoft and can still show warnings for newly signed or low-reputation releases even when Authenticode verification succeeds. Keep signing every Windows release with the same publisher certificate where possible so reputation can build over time.
+
 **Renewal**
 
 - Create a new Certificate Signing Request (CSR) file with DigiCert® Certificate Utility application. 
@@ -104,5 +116,4 @@ echo "`whoami` ALL=(ALL) NOPASSWD:ALL" | sudo tee /etc/sudoers.d/`whoami` && sud
 ```
 
 Use WSL 1 otherwise you cannot enter anything to the console (sudo password, appleid). https://github.com/microsoft/WSL/issues/4424
-
 

--- a/WalletWasabi.Packager/ArgsProcessor.cs
+++ b/WalletWasabi.Packager/ArgsProcessor.cs
@@ -24,6 +24,8 @@ public class ArgsProcessor
 
 	public bool IsSign() => IsOneOf("sign");
 
+	public bool IsSignWindowsBinaries() => IsOneOf("sign-windows-binaries");
+
 	public bool IsGeneratePrivateKey() => IsOneOf("generatekeys");
 
 	private bool IsOneOf(params string[] values)

--- a/WalletWasabi.Packager/Program.cs
+++ b/WalletWasabi.Packager/Program.cs
@@ -25,6 +25,9 @@ namespace WalletWasabi.Packager;
 public static class Program
 {
 	public const string PfxPath = "C:\\digicert.pfx";
+	private const string DefaultWindowsSigningCertificateThumbprint = "11b23b66b96261629cff1b08a28518309352ff7d";
+	private const string WindowsSigningCertificateThumbprintEnvironmentVariable = "GINGER_WINDOWS_SIGN_CERT_SHA1";
+	private const string WindowsSignToolDirectory = @"C:\Program Files (x86)\Microsoft SDKs\ClickOnce\SignTool";
 
 	public const string DaemonExecutableName = Constants.DaemonExecutableName;
 	public const string ExecutableName = Constants.ExecutableName;
@@ -93,6 +96,11 @@ public static class Program
 		{
 			await SignAsync().ConfigureAwait(false);
 		}
+
+		if (argsProcessor.IsSignWindowsBinaries())
+		{
+			SignWindowsPublishedBinaries();
+		}
 	}
 
 	private static void ReportStatus()
@@ -145,13 +153,7 @@ public static class Program
 				}
 
 				File.Move(msiPath, newMsiPath);
-
-				StartProcessAndWaitForExit(
-					"cmd.exe",
-					@"C:\Program Files (x86)\Microsoft SDKs\ClickOnce\SignTool",  // Set the working directory
-					null,
-					$"/c \"signtool.exe sign /sha1 \"11b23b66b96261629cff1b08a28518309352ff7d\" /tr http://time.certum.pl /td sha256 /fd sha256 /v \"{newMsiPath}\" && exit\""
-				);
+				SignWindowsFile(newMsiPath);
 
 				await IoHelpers.TryDeleteDirectoryAsync(publishedFolder).ConfigureAwait(false);
 				Console.WriteLine($"Deleted {publishedFolder}");
@@ -208,6 +210,55 @@ public static class Program
 		await WasabiSignerHelpers.VerifyInstallerFileHashesAsync(finalFiles, sha256sumAscFilePath).ConfigureAwait(false);
 
 		IoHelpers.OpenFolderInFileExplorer(BinDistDirectory);
+	}
+
+	private static void SignWindowsPublishedBinaries()
+	{
+		if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+		{
+			throw new PlatformNotSupportedException("Windows binaries can only be signed on Windows.");
+		}
+
+		string publishedFolder = Path.Combine(BinDistDirectory, "win-x64");
+		if (!Directory.Exists(publishedFolder))
+		{
+			throw new DirectoryNotFoundException($"Published Windows binaries do not exist. Expected path: {publishedFolder}.");
+		}
+
+		string[] gingerExecutables =
+		{
+			Path.Combine(publishedFolder, $"{ExecutableName}.exe"),
+			Path.Combine(publishedFolder, $"{DaemonExecutableName}.exe")
+		};
+
+		foreach (var executablePath in gingerExecutables)
+		{
+			if (!File.Exists(executablePath))
+			{
+				throw new FileNotFoundException("Published executable does not exist.", executablePath);
+			}
+
+			SignWindowsFile(executablePath);
+		}
+	}
+
+	private static void SignWindowsFile(string filePath)
+	{
+		string certificateThumbprint =
+			Environment.GetEnvironmentVariable(WindowsSigningCertificateThumbprintEnvironmentVariable)
+			?? DefaultWindowsSigningCertificateThumbprint;
+
+		string arguments = string.Join(
+			" ",
+			"sign",
+			$"/sha1 {certificateThumbprint}",
+			"/tr http://time.certum.pl",
+			"/td sha256",
+			"/fd sha256",
+			"/v",
+			$"\"{filePath}\"");
+
+		StartProcessAndWaitForExit(Path.Combine(WindowsSignToolDirectory, "signtool.exe"), WindowsSignToolDirectory, arguments: arguments);
 	}
 
 	private static async Task PublishAsync()

--- a/WalletWasabi.Packager/scripts/Wasabi_release.ps1
+++ b/WalletWasabi.Packager/scripts/Wasabi_release.ps1
@@ -15,6 +15,7 @@ $visualStudioPath = "C:\Program Files\Microsoft Visual Studio\2022\Community\Com
 # Change directory to the wallet wasabi packager folder
 cd $walletWasabiPath
 dotnet run -- publish
+dotnet run -- sign-windows-binaries
 
 $host.UI.RawUI.ForegroundColor = "Green"
 $host.UI.RawUI.BackgroundColor = "Black"


### PR DESCRIPTION
## Summary

Fixes the Windows release packaging flow so the Ginger executables are Authenticode-signed before WiX harvests them into the MSI, then keeps signing the final MSI as before.

## Why

Fixes #149. The issue reports a Windows signature warning during first-time install. Signing only the final MSI leaves the embedded application executables unsigned, which weakens the Windows trust chain and release hygiene. This does not guarantee immediate SmartScreen reputation, because Microsoft controls publisher/file reputation, but it makes the release artifacts correctly signed end to end.

## Changes

- Adds a `sign-windows-binaries` packager command.
- Signs `wassabee.exe` and `wassabeed.exe` in `bin/dist/win-x64` before the MSI is built.
- Reuses the same signtool helper for the final MSI signing.
- Allows overriding the certificate thumbprint with `GINGER_WINDOWS_SIGN_CERT_SHA1`.
- Updates release docs with Authenticode verification steps and SmartScreen reputation notes.

## Validation

- `dotnet build WalletWasabi.Packager\WalletWasabi.Packager.csproj --configuration Release --no-restore`
  - Result: succeeded with existing analyzer/nullability warnings, 0 errors.