### PR TITLE
Bump version to 2.0.26.0

### DIFF
--- a/WalletWasabi/Helpers/Constants.cs
+++ b/WalletWasabi/Helpers/Constants.cs
@@ -90,7 +90,7 @@ public static class Constants
 
 	public static readonly Money MaximumNumberOfBitcoinsMoney = Money.Coins(MaximumNumberOfBitcoins);
 
-	public static readonly Version ClientVersion = new(2, 0, 25, 0);
+	public static readonly Version ClientVersion = new(2, 0, 26, 0);
 
 	public static readonly Version HwiVersion = new("3.2.0");
 	public static readonly Version BitcoinCoreVersion = new("31.0");


### PR DESCRIPTION
## What changed

- Bumped `Constants.ClientVersion` from `2.0.25.0` to `2.0.26.0`.

## Why

Prepare GingerWallet for the existing `v2.0.26` draft release and keep the client version aligned with the matching GingerBackend version PR (`GingerPrivacy/GingerBackend#474`).

## Impact

- Client version reporting and release packaging now use `2.0.26`.
- No protocol, configuration, dependency, or runtime behavior changes.

## Validation

- Locked restore succeeded.
- Release build succeeded with 0 errors (117 existing warnings).
- `WasabiClientTests`: 2 passed, 0 failed.
- `git diff --check` passed.
