### PR TITLE
Harden Windows certificate configuration

### DIFF
--- a/WalletWasabi.Documentation/ClientRelease/ClientDeployment.md
+++ b/WalletWasabi.Documentation/ClientRelease/ClientDeployment.md
@@ -78,32 +78,33 @@ Backport is a branch. It is used for creating silent releases (hotfixes, small i
 
 ## Code signing certificate
 
-Digicert holds our Code Signing Certificate under the name "zkSNACKs Limited".
-- Issuing CA: DigiCert SHA2 Assured ID Code Signing CA
+Certum issues the Windows code-signing certificate for the "Open Source Developer Martin Rimóczi" publisher through SimplySign.
+
+- Issuing CA: Certum Code Signing 2021 CA
 - Platform: Microsoft Authenticode
 - Type: Code Signing
-- CSR Key Size: 3072
 
-The release script signs the Windows application executables before the MSI is built, then signs the final MSI after WiX finishes. By default it uses the thumbprint compiled into the packager, but the release machine can override it without code changes:
+The release script signs the Windows application executables before the MSI is built, then signs the final MSI after WiX finishes. The packager requires the certificate's SHA-1 thumbprint in the `GINGER_WINDOWS_SIGN_CERT_SHA1` environment variable. This SHA-1 value only selects the certificate; file signatures and RFC 3161 timestamps use SHA-256.
 
+Before packaging:
+
+1. Sign in to SimplySign Desktop and make sure the current, valid code-signing certificate is available.
+2. Open the certificate, select the **Details** tab, and copy the **Thumbprint** value as described in [Certum's SignTool instructions](https://www.files.certum.eu/documents/manual_en/Signing_with_the_use_of_jarsigner_tool_and_signtool.pdf). Do not use the certificate serial number.
+3. Set the thumbprint for the current PowerShell session:
+
+```powershell
+$env:GINGER_WINDOWS_SIGN_CERT_SHA1 = "<certificate-thumbprint>"
 ```
-setx GINGER_WINDOWS_SIGN_CERT_SHA1 <certificate-thumbprint>
+
+The packager ignores whitespace and common invisible direction marks copied by the Windows certificate viewer, but otherwise requires exactly 40 hexadecimal characters. To persist the value for future shells, run:
+
+```powershell
+setx GINGER_WINDOWS_SIGN_CERT_SHA1 "<certificate-thumbprint>"
 ```
 
-SmartScreen reputation is controlled by Microsoft and can still show warnings for newly signed or low-reputation releases even when Authenticode verification succeeds. Keep signing every Windows release with the same publisher certificate where possible so reputation can build over time.
+`setx` only affects newly started processes, so open a new PowerShell window before running the release script.
 
-**Renewal**
-
-- Create a new Certificate Signing Request (CSR) file with DigiCert® Certificate Utility application. 
-   DigiCert® Certificate Utility is using the logged in user's public key to encrypt the file and only the same user can decrypt it after we receive the certificate.
-   Make sure to create the CSR file in David's profile (or wherever the release script is located)!
-- Upload the CSR file to DigiCert.
-- Wait for DigiCert to issue a new `zksnacks_limited.p7b` file.
-- Import the `zksnacks_limited.p7b` file to DigiCert® Certificate Utility.
-- Choose a friendly name for the certificate and apply the default password to it.
-- Export the `zksnacks_limited.pfx` to `C:\zksnacks_limited.pfx`.
-- Rename `C:\zksnacks_limited.pfx` to `C:\digicert.pfx`, so the Packager can find it!!
-
+SmartScreen reputation is controlled by Microsoft and can still show warnings for newly signed or low-reputation releases even when Authenticode verification succeeds. Keep the publisher identity consistent across certificate renewals and sign every Windows release so reputation can build over time.
 
 ## Packager environment setup
 
@@ -116,4 +117,3 @@ echo "`whoami` ALL=(ALL) NOPASSWD:ALL" | sudo tee /etc/sudoers.d/`whoami` && sud
 ```
 
 Use WSL 1 otherwise you cannot enter anything to the console (sudo password, appleid). https://github.com/microsoft/WSL/issues/4424
-

--- a/WalletWasabi.Packager/Program.cs
+++ b/WalletWasabi.Packager/Program.cs
@@ -24,8 +24,6 @@ namespace WalletWasabi.Packager;
 /// </summary>
 public static class Program
 {
-	public const string PfxPath = "C:\\digicert.pfx";
-	private const string DefaultWindowsSigningCertificateThumbprint = "11b23b66b96261629cff1b08a28518309352ff7d";
 	private const string WindowsSigningCertificateThumbprintEnvironmentVariable = "GINGER_WINDOWS_SIGN_CERT_SHA1";
 	private const string WindowsSignToolDirectory = @"C:\Program Files (x86)\Microsoft SDKs\ClickOnce\SignTool";
 
@@ -244,9 +242,7 @@ public static class Program
 
 	private static void SignWindowsFile(string filePath)
 	{
-		string certificateThumbprint =
-			Environment.GetEnvironmentVariable(WindowsSigningCertificateThumbprintEnvironmentVariable)
-			?? DefaultWindowsSigningCertificateThumbprint;
+		string certificateThumbprint = GetWindowsSigningCertificateThumbprint();
 
 		string arguments = string.Join(
 			" ",
@@ -259,6 +255,30 @@ public static class Program
 			$"\"{filePath}\"");
 
 		StartProcessAndWaitForExit(Path.Combine(WindowsSignToolDirectory, "signtool.exe"), WindowsSignToolDirectory, arguments: arguments);
+	}
+
+	private static string GetWindowsSigningCertificateThumbprint()
+	{
+		string? configuredThumbprint = Environment.GetEnvironmentVariable(WindowsSigningCertificateThumbprintEnvironmentVariable);
+
+		if (string.IsNullOrWhiteSpace(configuredThumbprint))
+		{
+			throw new InvalidOperationException(
+				$"Set {WindowsSigningCertificateThumbprintEnvironmentVariable} to the 40-character SHA-1 thumbprint of the Windows code-signing certificate.");
+		}
+
+		string certificateThumbprint = new(
+			configuredThumbprint
+				.Where(character => !char.IsWhiteSpace(character) && character is not '\u200e' and not '\u200f')
+				.ToArray());
+
+		if (certificateThumbprint.Length != 40 || !certificateThumbprint.All(Uri.IsHexDigit))
+		{
+			throw new InvalidOperationException(
+				$"{WindowsSigningCertificateThumbprintEnvironmentVariable} must contain exactly 40 hexadecimal characters.");
+		}
+
+		return certificateThumbprint.ToUpperInvariant();
 	}
 
 	private static async Task PublishAsync()

--- a/WalletWasabi.Packager/scripts/Wasabi_release.ps1
+++ b/WalletWasabi.Packager/scripts/Wasabi_release.ps1
@@ -1,6 +1,20 @@
 # If you are not allowed to run this script, run the following command in your PowerShell console: 
 # Set-ExecutionPolicy RemoteSigned
 
+$ErrorActionPreference = "Stop"
+
+function Invoke-Packager {
+	param(
+		[Parameter(Mandatory)]
+		[string] $Command
+	)
+
+	dotnet run -- $Command
+	if ($LASTEXITCODE -ne 0) {
+		throw "Packager command '$Command' failed with exit code $LASTEXITCODE."
+	}
+}
+
 $host.UI.RawUI.ForegroundColor = "Green"
 $host.UI.RawUI.BackgroundColor = "Black"
 Read-Host -Prompt 'Releasing Wasabi Wallet - Insert a pendrive to store macOS notarization candidate files [Press ENTER]'
@@ -14,8 +28,8 @@ $visualStudioPath = "C:\Program Files\Microsoft Visual Studio\2022\Community\Com
 
 # Change directory to the wallet wasabi packager folder
 cd $walletWasabiPath
-dotnet run -- publish
-dotnet run -- sign-windows-binaries
+Invoke-Packager "publish"
+Invoke-Packager "sign-windows-binaries"
 
 $host.UI.RawUI.ForegroundColor = "Green"
 $host.UI.RawUI.BackgroundColor = "Black"
@@ -31,6 +45,6 @@ $host.UI.RawUI.ForegroundColor = "Green"
 $host.UI.RawUI.BackgroundColor = "Black"
 Read-Host -Prompt 'Wait until WiX building the MSI installer, then [Press ENTER]'
 Read-Host -Prompt 'Wait until macOS notarization is done and insert the pendrive to this PC [Press ENTER]'
-dotnet run -- sign
+Invoke-Packager "sign"
 
 Read-Host -Prompt 'Release finished [Press ENTER]'


### PR DESCRIPTION
## Summary

- require the Windows signing certificate thumbprint through `GINGER_WINDOWS_SIGN_CERT_SHA1`
- normalize certificate-viewer whitespace and direction marks, then validate the thumbprint as 40 hexadecimal characters
- stop the release script immediately when a packager command fails
- replace obsolete DigiCert/PFX documentation with the current Certum SimplySign workflow

## Why

The previous certificate expired on July 23, 2026, while the packager still contained its thumbprint as a compiled fallback. A renewed certificate has a different thumbprint, so silently retaining the old fallback makes release signing fail and requires a code change at every renewal.

The release script also did not stop after a failed native `dotnet run` command, allowing packaging to continue after signing failed.

## Impact

Release operators must set `GINGER_WINDOWS_SIGN_CERT_SHA1` to the current certificate thumbprint before signing. Missing or malformed configuration now fails with a clear error. Windows ZIP creation remains unchanged and continues to contain unsigned deterministic binaries.

## Validation

- `dotnet build WalletWasabi.Packager\WalletWasabi.Packager.csproj --configuration Release -p:RestoreLockedMode=true`
- PowerShell parser validation for `Wasabi_release.ps1`
- direct checks of thumbprint normalization and rejection of missing/malformed values
- `git diff --check`
