### PR TITLE
Require credentials for JSON-RPC server

### DIFF
--- a/WalletWasabi.Daemon/Global.cs
+++ b/WalletWasabi.Daemon/Global.cs
@@ -304,7 +304,17 @@ public class Global
 			? Config.JsonRpcServerPrefixes.Append($"http://+:37129/").ToArray()
 			: Config.JsonRpcServerPrefixes;
 
-		var jsonRpcServerConfig = new JsonRpcServerConfiguration(Config.JsonRpcServerEnabled, Config.JsonRpcUser, Config.JsonRpcPassword, prefixes);
+		JsonRpcServerConfiguration jsonRpcServerConfig;
+		try
+		{
+			jsonRpcServerConfig = new JsonRpcServerConfiguration(Config.JsonRpcServerEnabled, Config.JsonRpcUser, Config.JsonRpcPassword, prefixes);
+		}
+		catch (ArgumentException e)
+		{
+			Logger.LogWarning($"Failed to start {nameof(JsonRpcServer)}: {e.Message}");
+			return;
+		}
+
 		if (jsonRpcServerConfig.IsEnabled)
 		{
 			var wasabiJsonRpcService = new Rpc.WasabiJsonRpcService(global: this);

--- a/WalletWasabi.Tests/UnitTests/Rpc/JsonRpcServerConfigurationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Rpc/JsonRpcServerConfigurationTests.cs
@@ -1,0 +1,37 @@
+using WalletWasabi.Rpc;
+using Xunit;
+
+namespace WalletWasabi.Tests.UnitTests.Rpc;
+
+public class JsonRpcServerConfigurationTests
+{
+	private static readonly string[] Prefixes = ["http://localhost:37128/"];
+
+	[Theory]
+	[InlineData("", "password")]
+	[InlineData("user", "")]
+	[InlineData(" ", "password")]
+	[InlineData("user", " ")]
+	public void EnabledServerRequiresCompleteCredentials(string user, string password)
+	{
+		var exception = Assert.Throws<ArgumentException>(() => new JsonRpcServerConfiguration(true, user, password, Prefixes));
+
+		Assert.Contains("requires both", exception.Message, StringComparison.OrdinalIgnoreCase);
+	}
+
+	[Fact]
+	public void DisabledServerAllowsMissingCredentials()
+	{
+		var configuration = new JsonRpcServerConfiguration(false, "", "", Prefixes);
+
+		Assert.False(configuration.RequiresCredentials);
+	}
+
+	[Fact]
+	public void EnabledServerAllowsCompleteCredentials()
+	{
+		var configuration = new JsonRpcServerConfiguration(true, "user", "password", Prefixes);
+
+		Assert.True(configuration.RequiresCredentials);
+	}
+}

--- a/WalletWasabi.Tests/UnitTests/Rpc/JsonRpcServerConfigurationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Rpc/JsonRpcServerConfigurationTests.cs
@@ -24,7 +24,7 @@ public class JsonRpcServerConfigurationTests
 	{
 		var configuration = new JsonRpcServerConfiguration(false, "", "", Prefixes);
 
-		Assert.False(configuration.RequiresCredentials);
+		Assert.False(configuration.HasCredentials);
 	}
 
 	[Fact]
@@ -32,6 +32,6 @@ public class JsonRpcServerConfigurationTests
 	{
 		var configuration = new JsonRpcServerConfiguration(true, "user", "password", Prefixes);
 
-		Assert.True(configuration.RequiresCredentials);
+		Assert.True(configuration.HasCredentials);
 	}
 }

--- a/WalletWasabi/Rpc/JsonRpcServer.cs
+++ b/WalletWasabi/Rpc/JsonRpcServer.cs
@@ -141,7 +141,7 @@ public class JsonRpcServer : BackgroundService
 	{
 		if (!Config.RequiresCredentials)
 		{
-			return true;
+			return false;
 		}
 
 		var user = context.User;

--- a/WalletWasabi/Rpc/JsonRpcServer.cs
+++ b/WalletWasabi/Rpc/JsonRpcServer.cs
@@ -139,7 +139,7 @@ public class JsonRpcServer : BackgroundService
 
 	private bool IsAuthorized(HttpListenerContext context)
 	{
-		if (!Config.RequiresCredentials)
+		if (!Config.HasCredentials)
 		{
 			return false;
 		}

--- a/WalletWasabi/Rpc/JsonRpcServerConfiguration.cs
+++ b/WalletWasabi/Rpc/JsonRpcServerConfiguration.cs
@@ -8,6 +8,11 @@ public class JsonRpcServerConfiguration
 		JsonRpcUser = jsonRpcUser;
 		JsonRpcPassword = jsonRpcPassword;
 		Prefixes = prefixes;
+
+		if (IsEnabled && !RequiresCredentials)
+		{
+			throw new ArgumentException("The JSON-RPC server requires both a non-empty user name and password.");
+		}
 	}
 
 	public bool IsEnabled { get; }
@@ -15,5 +20,5 @@ public class JsonRpcServerConfiguration
 	public string JsonRpcPassword { get; }
 	public string[] Prefixes { get; }
 
-	public bool RequiresCredentials => !string.IsNullOrEmpty(JsonRpcUser) && !string.IsNullOrEmpty(JsonRpcPassword);
+	public bool RequiresCredentials => !string.IsNullOrWhiteSpace(JsonRpcUser) && !string.IsNullOrWhiteSpace(JsonRpcPassword);
 }

--- a/WalletWasabi/Rpc/JsonRpcServerConfiguration.cs
+++ b/WalletWasabi/Rpc/JsonRpcServerConfiguration.cs
@@ -9,7 +9,7 @@ public class JsonRpcServerConfiguration
 		JsonRpcPassword = jsonRpcPassword;
 		Prefixes = prefixes;
 
-		if (IsEnabled && !RequiresCredentials)
+		if (IsEnabled && !HasCredentials)
 		{
 			throw new ArgumentException("The JSON-RPC server requires both a non-empty user name and password.");
 		}
@@ -20,5 +20,5 @@ public class JsonRpcServerConfiguration
 	public string JsonRpcPassword { get; }
 	public string[] Prefixes { get; }
 
-	public bool RequiresCredentials => !string.IsNullOrWhiteSpace(JsonRpcUser) && !string.IsNullOrWhiteSpace(JsonRpcPassword);
+	public bool HasCredentials => !string.IsNullOrWhiteSpace(JsonRpcUser) && !string.IsNullOrWhiteSpace(JsonRpcPassword);
 }


### PR DESCRIPTION
## Summary

- Require a non-empty JSON-RPC username and password whenever the server is enabled.
- Make the request authentication gate fail closed if credentials are absent.
- Keep the wallet application running while refusing to start an invalidly configured RPC server.
- Add focused configuration tests.

## Risk assessment

The issue is configuration-dependent: JSON-RPC is disabled by default, loopback-bound by default, onion exposure is already rejected without credentials, and password-protected wallets still require their wallet password. However, an explicitly enabled unauthenticated RPC server can expose transaction methods to local or otherwise reachable callers, and an empty-passphrase wallet can sign with an empty password. Because the affected configuration can lead to loss of funds, the server should fail closed.

## Validation

- Targeted JSON-RPC tests: 6 passed, 0 failed.
- Full unit test suite: 966 passed, 0 failed, 0 skipped.
- The branch contains one commit on the current upstream `master` merge-base.
