### PR TITLE
Authenticate two-factor wallet encryption

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Helpers/TwoFactorAuthenticationHelpersTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Helpers/TwoFactorAuthenticationHelpersTests.cs
@@ -1,0 +1,46 @@
+using System.Security.Cryptography;
+using WalletWasabi.Helpers;
+using Xunit;
+
+namespace WalletWasabi.Tests.UnitTests.Helpers;
+
+public class TwoFactorAuthenticationHelpersTests
+{
+	private const string Prefix = "2fa-v2:";
+
+	[Fact]
+	public void AuthenticatedEncryptionRoundTrips()
+	{
+		const string plainText = "{\"wallet\":\"authenticated\"}";
+		const string secret = "server-generated-secret";
+
+		string encrypted = TwoFactorAuthenticationHelpers.EncryptString(plainText, secret);
+
+		Assert.StartsWith(Prefix, encrypted, StringComparison.Ordinal);
+		Assert.True(TwoFactorAuthenticationHelpers.IsUsingAuthenticatedEncryption(encrypted));
+		Assert.Equal(plainText, TwoFactorAuthenticationHelpers.DecryptString(encrypted, secret));
+	}
+
+	[Fact]
+	public void AuthenticatedEncryptionRejectsTampering()
+	{
+		const string secret = "server-generated-secret";
+		string encrypted = TwoFactorAuthenticationHelpers.EncryptString("wallet data", secret);
+		byte[] payload = Convert.FromBase64String(encrypted[Prefix.Length..]);
+		payload[^1] ^= 1;
+		string tampered = Prefix + Convert.ToBase64String(payload);
+
+		Assert.Throws<CryptographicException>(() => TwoFactorAuthenticationHelpers.DecryptString(tampered, secret));
+	}
+
+	[Fact]
+	public void LegacyEncryptionRemainsReadable()
+	{
+		const string legacyCipherText = "AAECAwQFBgcICQoLDA0OD9jstQUxVz1YuwT0kiVad37zAZY49iUjI2TWHpG+otBZ";
+
+		string decrypted = TwoFactorAuthenticationHelpers.DecryptString(legacyCipherText, "server-generated-secret");
+
+		Assert.False(TwoFactorAuthenticationHelpers.IsUsingAuthenticatedEncryption(legacyCipherText));
+		Assert.Equal("{\"wallet\":\"legacy\"}", decrypted);
+	}
+}

--- a/WalletWasabi/Helpers/TwoFactorAuthenticationHelpers.cs
+++ b/WalletWasabi/Helpers/TwoFactorAuthenticationHelpers.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Security.Cryptography;
 using System.Text;
+using WalletWasabi.Crypto;
 
 namespace WalletWasabi.Helpers;
 
@@ -11,25 +12,24 @@ public class WalletEncryption
 
 public static class TwoFactorAuthenticationHelpers
 {
+	private const string AuthenticatedEncryptionPrefix = "2fa-v2:";
+
 	public static string EncryptString(string plainText, string secret)
 	{
-		using Aes aes = Aes.Create();
-		aes.Key = GetEncryptionKey(secret);
-
-		using MemoryStream memoryStream = new();
-		memoryStream.Write(aes.IV, 0, 16);
-		using (ICryptoTransform encryptor = aes.CreateEncryptor())
-		using (CryptoStream cryptoStream = new(memoryStream, encryptor, CryptoStreamMode.Write))
-		{
-			byte[] plainBytes = Encoding.UTF8.GetBytes(plainText);
-			cryptoStream.Write(plainBytes, 0, plainBytes.Length);
-			cryptoStream.FlushFinalBlock();
-		}
-
-		return Convert.ToBase64String(memoryStream.ToArray());
+		return AuthenticatedEncryptionPrefix + StringCipher.Encrypt(plainText, secret);
 	}
 
 	public static string DecryptString(string cipherText, string secret)
+	{
+		return IsUsingAuthenticatedEncryption(cipherText)
+			? StringCipher.Decrypt(cipherText[AuthenticatedEncryptionPrefix.Length..], secret)
+			: DecryptLegacyString(cipherText, secret);
+	}
+
+	public static bool IsUsingAuthenticatedEncryption(string cipherText) =>
+		cipherText.StartsWith(AuthenticatedEncryptionPrefix, StringComparison.Ordinal);
+
+	private static string DecryptLegacyString(string cipherText, string secret)
 	{
 		using Aes aes = Aes.Create();
 		aes.Key = GetEncryptionKey(secret);

--- a/WalletWasabi/Services/TwoFactorAuthenticationService.cs
+++ b/WalletWasabi/Services/TwoFactorAuthenticationService.cs
@@ -49,10 +49,17 @@ public class TwoFactorAuthenticationService
 		foreach (var walletFileInfo in WalletDirectories.EnumerateWalletFiles())
 		{
 			KeyManager? keyManager;
+			bool isLegacyEncryption = false;
 			try
 			{
 				keyManager = KeyManager.FromFile(walletFileInfo.FullName, secret);
-				continue;
+				string walletFileContent = File.ReadAllText(walletFileInfo.FullName);
+				if (TwoFactorAuthenticationHelpers.IsUsingAuthenticatedEncryption(walletFileContent))
+				{
+					continue;
+				}
+
+				isLegacyEncryption = true;
 			}
 			catch (IOException)
 			{
@@ -69,7 +76,9 @@ public class TwoFactorAuthenticationService
 			var (walletFilePath, walletBackupFilePath, _) = WalletDirectories.GetWalletFilePaths(keyManager.WalletName);
 			keyManager.EncryptionKey = secret;
 
-			Logger.LogInfo($"Wallet file was not encrypted '{walletFileInfo.Name}', encrypting... ");
+			Logger.LogInfo(isLegacyEncryption
+				? $"Wallet file used legacy encryption '{walletFileInfo.Name}', migrating... "
+				: $"Wallet file was not encrypted '{walletFileInfo.Name}', encrypting... ");
 			keyManager.ToFile(walletFilePath);
 			keyManager.ToFile(walletBackupFilePath);
 		}


### PR DESCRIPTION
## Summary

- Write 2FA-protected wallet data using GingerWallet's existing salted PBKDF2 plus AES-CBC/HMAC authenticated format.
- Prefix the new format so it can be identified reliably.
- Retain read compatibility with legacy AES-CBC wallet files.
- Migrate legacy files immediately after the next successful 2FA login.
- Add round-trip, tamper-rejection, and legacy-compatibility tests.

## Risk assessment

The previous format encrypted data without authenticating the ciphertext. The practical risk is lower than a direct wallet-draining vulnerability because the 2FA secret is server-generated and high entropy, and an attacker needs local file-write access. Still, authenticated encryption is a worthwhile defense-in-depth improvement and can be introduced without breaking existing wallets.

## Validation

- Targeted 2FA encryption tests: 3 passed, 0 failed.
- Full unit test suite: 963 passed, 0 failed, 0 skipped.
- The branch contains one commit on the current upstream `master` merge-base.
