### PR TITLE
Make Secret Hunt opt-in by default

### DIFF
--- a/WalletWasabi.Tests/UnitTests/SecretHunt/SecretHuntResultsTests.cs
+++ b/WalletWasabi.Tests/UnitTests/SecretHunt/SecretHuntResultsTests.cs
@@ -1,0 +1,15 @@
+using WalletWasabi.SecretHunt;
+using Xunit;
+
+namespace WalletWasabi.Tests.UnitTests.SecretHunt;
+
+public class SecretHuntResultsTests
+{
+	[Fact]
+	public void SecretHuntIsDisabledByDefault()
+	{
+		var results = new SecretHuntResults();
+
+		Assert.False(results.Enabled);
+	}
+}

--- a/WalletWasabi.Tests/UnitTests/Wallet/WalletJsonTest.cs
+++ b/WalletWasabi.Tests/UnitTests/Wallet/WalletJsonTest.cs
@@ -333,7 +333,7 @@ public class WalletJsonTest
 		    }
 		  ],
 		  "SecretHuntResults": {
-		    "Enabled": true,
+		    "Enabled": false,
 		    "Results": []
 		  }
 		}

--- a/WalletWasabi/SecretHunt/SecretHuntResults.cs
+++ b/WalletWasabi/SecretHunt/SecretHuntResults.cs
@@ -7,7 +7,7 @@ namespace WalletWasabi.SecretHunt;
 
 public class SecretHuntResults
 {
-	public bool Enabled { get; set; } = true;
+	public bool Enabled { get; set; } = false;
 	public List<SecretHuntEventResult> Results { get; set; } = [];
 }
 


### PR DESCRIPTION
## Summary

- Disable Secret Hunt by default for newly created/default wallet settings.
- Update the persisted wallet JSON expectation.
- Preserve the explicit setting of existing wallets.

## Risk assessment

The report correctly notes that a Secret Hunt request contains a selected input and its ownership proof. The practical privacy impact is limited because the request uses a fresh Tor circuit, includes no wallet identifier or output link, and the coordinator already observes CoinJoin inputs. This is therefore low/informational severity. However, the feature was enabled by default, so making it opt-in is a small, low-risk privacy-by-default improvement.

## Validation

- Targeted Secret Hunt and wallet JSON tests: 2 passed, 0 failed.
- Full unit test suite: 961 passed, 0 failed, 0 skipped.
- The branch contains one commit on the current upstream `master` merge-base.
