### PR TITLE
Handle missing Windows startup registry key

### DIFF
--- a/WalletWasabi.Fluent/Helpers/WindowsStartupHelper.cs
+++ b/WalletWasabi.Fluent/Helpers/WindowsStartupHelper.cs
@@ -25,7 +25,19 @@ public static class WindowsStartupHelper
 			throw new InvalidOperationException($"Path: {pathToExeFile} does not exist.");
 		}
 
-		using RegistryKey key = Registry.CurrentUser.OpenSubKey(KeyPath, writable: true) ?? throw new InvalidOperationException("Registry operation failed.");
+		using RegistryKey? key = runOnSystemStartup
+			? Registry.CurrentUser.CreateSubKey(KeyPath, writable: true)
+			: Registry.CurrentUser.OpenSubKey(KeyPath, writable: true);
+
+		if (key is null)
+		{
+			if (runOnSystemStartup)
+			{
+				throw new InvalidOperationException("Registry operation failed.");
+			}
+
+			return;
+		}
 
 		var existingPath = key.GetValue(nameof(WalletWasabi));
 		if (existingPath is null && runOnSystemStartup)

--- a/WalletWasabi.Tests/Helpers/WindowsStartupTestHelper.cs
+++ b/WalletWasabi.Tests/Helpers/WindowsStartupTestHelper.cs
@@ -6,18 +6,16 @@ namespace WalletWasabi.Tests.Helpers;
 
 public class WindowsStartupTestHelper
 {
-	private const string PathToRegistyKey = "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run";
+	private const string PathToRegistryKey = "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run";
 
 	public bool RegistryKeyExists()
 	{
-		bool result = false;
-
-		if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+		if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 		{
-			RegistryKey? registryKey = Registry.CurrentUser.OpenSubKey(PathToRegistyKey, false) ?? throw new InvalidOperationException("Registry operation failed.");
-			result = registryKey.GetValueNames().Contains(nameof(WalletWasabi));
+			return false;
 		}
 
-		return result;
+		using RegistryKey? registryKey = Registry.CurrentUser.OpenSubKey(PathToRegistryKey, false);
+		return registryKey?.GetValueNames().Contains(nameof(WalletWasabi)) is true;
 	}
 }


### PR DESCRIPTION
## Summary

- create the Windows startup Run registry key when enabling startup
- treat a missing Run key as an ordinary disabled state when checking or disabling startup
- prevent the Windows startup unit test from failing on clean runner profiles

## Test plan

- `dotnet test WalletWasabi.Tests\WalletWasabi.Tests.csproj --no-restore --no-build --configuration Release --filter "FullyQualifiedName~StartWasabiOnSystemStartupTests" --logger "console;verbosity=minimal"`
- Passed: 2, Failed: 0

This addresses the failure seen in https://github.com/GingerPrivacy/GingerWallet/actions/runs/32564529163/job/97011108157?pr=192.