### PR TITLE
[PoC] Configure Trezor Suite CoinJoin for Ginger

### DIFF
--- a/WalletWasabi.Documentation/Guides/TrezorSuiteGingerCoinJoinPoc.md
+++ b/WalletWasabi.Documentation/Guides/TrezorSuiteGingerCoinJoinPoc.md
@@ -1,0 +1,141 @@
+# Testing the Trezor Suite Ginger CoinJoin PoC
+
+> [!WARNING]
+> This pull request is an experimental proof of concept, not a supported release feature. It changes an internal Trezor Suite debug setting and has not yet completed a real hardware CoinJoin round. Use only an empty or low-value test account. Never test with funds you cannot afford to lose.
+
+## What this PoC tests
+
+The PoC adds a **Settings > Trezor** tab to Ginger Wallet. It:
+
+1. Finds the installed Trezor Suite executable on Windows, macOS, or Linux, with a manual file picker as a fallback.
+2. Checks that the Ginger coordinator and backend are reachable.
+3. Starts Trezor Suite briefly with a random loopback Chrome DevTools Protocol port.
+4. Backs up Suite's existing `coinjoinDebugSettings/debug` IndexedDB value.
+5. Preserves unrelated debug fields and applies these Bitcoin overrides:
+   - Coordinator: `https://api.gingerwallet.io/WabiSabi/`
+   - WabiSabi backend: `https://api.gingerwallet.io/`
+   - Affiliation ID: `null`
+6. Reads the value back and marks it configured only if all three values match.
+7. Closes the temporary Suite process and opens Suite normally.
+
+Ginger does not monitor Suite after launch and does not access the Trezor seed, PIN, passphrase, or private keys.
+
+## Prerequisites
+
+- A supported desktop operating system: Windows, macOS, or Linux.
+- The .NET SDK version selected by this repository's `global.json`.
+- A recent Trezor Suite desktop installation.
+- A Trezor hardware wallet only for the optional hardware test.
+- Trezor Suite fully closed before every **Configure**, **Repair**, or **Restore** operation.
+
+Record the operating system, Ginger commit, Trezor Suite version, device model, and firmware version for the test report. Do not include wallet identifiers or transaction details.
+
+## Build and run the PR
+
+Check out the pull request using either GitHub CLI:
+
+```shell
+gh pr checkout <PR_NUMBER>
+```
+
+Or fetch it with Git:
+
+```shell
+git fetch https://github.com/GingerPrivacy/GingerWallet.git pull/<PR_NUMBER>/head:trezor-suite-ginger-poc
+git switch trezor-suite-ginger-poc
+```
+
+Restore, build, and run Ginger:
+
+```shell
+dotnet restore --locked-mode
+dotnet build WalletWasabi.Fluent.Desktop/WalletWasabi.Fluent.Desktop.csproj --configuration Debug
+dotnet run --project WalletWasabi.Fluent.Desktop/WalletWasabi.Fluent.Desktop.csproj --configuration Debug
+```
+
+## Test 1: detection and configuration
+
+1. Close every Trezor Suite window and confirm Suite is no longer running.
+2. In Ginger, open **Settings > Trezor**.
+3. Confirm the tab shows:
+   - **Trezor Suite:** `Installed`
+   - A plausible **Trezor Suite version**
+   - **Ginger CoinJoin backend:** `Online`
+   - **Configuration:** `Not configured`
+   - **Last verified:** `Never`
+4. If Suite is not detected, click **Choose** and select its executable or app binary.
+5. Click **Configure and open Trezor Suite**.
+6. A temporary Suite/DevTools window may appear briefly. Ginger should close that process and open Suite normally.
+7. Return to Ginger and press **Refresh** if necessary.
+8. Confirm:
+   - **Configuration:** `Configured for Ginger`
+   - **Last verified:** contains the time of this test
+   - The primary button is now **Repair and open Trezor Suite**
+   - **Restore original configuration** is available
+
+`Installed` and `Online` only confirm prerequisites. The override is successful only when **Configuration** says `Configured for Ginger` and **Last verified** has a timestamp.
+
+## Test 2: failure handling
+
+1. Leave Trezor Suite running.
+2. Click **Repair and open Trezor Suite** in Ginger.
+3. Confirm Ginger reports the operation as failed rather than claiming it was verified.
+4. Close Suite completely and repeat the operation.
+5. Confirm the repair then succeeds and Suite opens normally.
+
+Do not terminate Ginger or Suite while Ginger is applying or restoring the setting.
+
+## Test 3: Suite CoinJoin behavior
+
+The presence and reachability of CoinJoin controls can differ between Trezor Suite versions. This is the main unanswered part of the PoC.
+
+1. Connect the Trezor device and open a Bitcoin account in Suite.
+2. Record whether Suite exposes any CoinJoin account or CoinJoin action after the override.
+3. If no CoinJoin action appears, stop here and report the result with the Suite version.
+4. If CoinJoin is available, use only a fresh, low-value test account.
+5. Confirm that Suite can load coordinator round information without an affiliation error.
+6. If you deliberately proceed into a round, verify every amount and destination on the hardware display. Abort on any unexpected prompt.
+7. Report the furthest successfully completed protocol phase. Do not publish addresses, transaction IDs, xpubs, screenshots containing balances, or full logs.
+
+Successful configuration proves only that Suite accepted the backend override. It does not prove that the current Suite UI exposes CoinJoin or that a hardware-signed round completes.
+
+## Test 4: restore the original Suite setting
+
+1. Close Trezor Suite completely.
+2. In **Settings > Trezor**, click **Restore original configuration**.
+3. Ginger should restore the exact previous debug value. If no value existed before the test, it deletes the value created by the PoC.
+4. Confirm Suite opens normally.
+5. Return to Ginger and confirm the configuration is no longer marked as configured and the Restore button is gone.
+
+Do this even if the functional CoinJoin test was unsuccessful.
+
+## Reporting results
+
+Use this sanitized template in the pull request:
+
+```text
+OS:
+Ginger commit:
+Trezor Suite version:
+Trezor model and firmware:
+
+Suite detected automatically: yes/no
+Override verified by Ginger: yes/no
+CoinJoin controls visible in Suite: yes/no
+Round information loaded: yes/no/not tested
+Hardware signing reached: yes/no/not tested
+Original setting restored: yes/no
+
+Error shown by Ginger, if any:
+Additional sanitized observations:
+```
+
+If a failure occurs, include the concise Ginger error and the relevant nearby log lines. Remove paths containing personal usernames and all wallet-specific data before posting.
+
+## Known PoC limitations
+
+- Trezor Suite must already be fully closed; Ginger does not terminate an independently running Suite instance.
+- Compatibility is version-dependent because this uses Suite's internal debug storage.
+- The loopback debugging interface exists only during configuration or restoration, but another local process could theoretically connect to it.
+- Backend reachability and the last successful write are checked; there is no continuous Suite monitoring.
+- No completed mainnet hardware CoinJoin has been established by this PoC yet.

--- a/WalletWasabi.Documentation/Guides/TrezorSuiteGingerCoinJoinPoc.md
+++ b/WalletWasabi.Documentation/Guides/TrezorSuiteGingerCoinJoinPoc.md
@@ -1,7 +1,7 @@
 # Testing the Trezor Suite Ginger CoinJoin PoC
 
 > [!WARNING]
-> This pull request is an experimental proof of concept, not a supported release feature. It changes an internal Trezor Suite debug setting and has not yet completed a real hardware CoinJoin round. Use only an empty or low-value test account. Never test with funds you cannot afford to lose.
+> This pull request is an experimental proof of concept, not a supported release feature. It changes an internal Trezor Suite debug setting and has received only limited real-hardware testing. One low-value round completed, but repeated-round behavior remains under investigation. Use only an empty or low-value test account. Never test with funds you cannot afford to lose.
 
 ## What this PoC tests
 
@@ -16,7 +16,7 @@ The PoC adds a **Settings > Trezor** tab to Ginger Wallet. It:
    - WabiSabi backend: `https://api.gingerwallet.io/`
    - Affiliation ID: `null`
 6. Reads the value back and marks it configured only if all three values match.
-7. Closes the temporary Suite process and opens Suite normally.
+7. Closes the temporary Suite process and opens Suite with diagnostic file logging enabled.
 
 Ginger does not monitor Suite after launch and does not access the Trezor seed, PIN, passphrase, or private keys.
 
@@ -72,6 +72,7 @@ dotnet run --project WalletWasabi.Fluent.Desktop/WalletWasabi.Fluent.Desktop.csp
    - **Last verified:** contains the time of this test
    - The primary button is now **Repair and open Trezor Suite**
    - **Restore original configuration** is available
+   - **Trezor Suite diagnostic logs** shows a path and **Open folder** opens it
 
 `Installed` and `Online` only confirm prerequisites. The override is successful only when **Configuration** says `Configured for Ginger` and **Last verified** has a timestamp.
 
@@ -87,7 +88,7 @@ Do not terminate Ginger or Suite while Ginger is applying or restoring the setti
 
 ## Test 3: Suite CoinJoin behavior
 
-The presence and reachability of CoinJoin controls can differ between Trezor Suite versions. This is the main unanswered part of the PoC.
+The presence and reachability of CoinJoin controls can differ between Trezor Suite versions. Automatic continuation into later rounds is still under investigation.
 
 1. Connect the Trezor device and open a Bitcoin account in Suite.
 2. Record whether Suite exposes any CoinJoin account or CoinJoin action after the override.
@@ -98,6 +99,12 @@ The presence and reachability of CoinJoin controls can differ between Trezor Sui
 7. Report the furthest successfully completed protocol phase. Do not publish addresses, transaction IDs, xpubs, screenshots containing balances, or full logs.
 
 Successful configuration proves only that Suite accepted the backend override. It does not prove that the current Suite UI exposes CoinJoin or that a hardware-signed round completes.
+
+### Collect diagnostic logs
+
+Every Trezor Suite process started by the Ginger Trezor tab uses Suite's `--log-write` and `--log-level=debug` switches. Logs are written to the `TrezorSuiteIntegration/SuiteLogs` directory below Ginger's platform-specific data directory. Use **Settings > Trezor > Open folder** to locate them. Coin-selection messages such as `Found account candidate`, `Utxos 0`, `detained`, or `Too many unavailable utxos` can help distinguish stale account data from a temporarily blocked input.
+
+When reporting a failure, close Suite first so that it flushes the current log, then copy only the relevant nearby `@trezor/coinjoin`, `CoinjoinClient`, or `CoinjoinBackend` lines. Logs may contain wallet metadata. Remove usernames, filesystem paths, wallet identifiers, addresses, transaction IDs, xpubs, balances, and any other sensitive details before sharing. Never post an entire raw log.
 
 ## Test 4: restore the original Suite setting
 
@@ -138,4 +145,5 @@ If a failure occurs, include the concise Ginger error and the relevant nearby lo
 - Compatibility is version-dependent because this uses Suite's internal debug storage.
 - The loopback debugging interface exists only during configuration or restoration, but another local process could theoretically connect to it.
 - Backend reachability and the last successful write are checked; there is no continuous Suite monitoring.
-- No completed mainnet hardware CoinJoin has been established by this PoC yet.
+- Diagnostic logs accumulate until the tester removes them from the folder shown by Ginger.
+- One low-value mainnet hardware CoinJoin has completed; reliable continuation into subsequent rounds has not yet been established.

--- a/WalletWasabi.Documentation/Guides/TrezorSuiteGingerCoinJoinPoc.md
+++ b/WalletWasabi.Documentation/Guides/TrezorSuiteGingerCoinJoinPoc.md
@@ -35,13 +35,13 @@ Record the operating system, Ginger commit, Trezor Suite version, device model, 
 Check out the pull request using either GitHub CLI:
 
 ```shell
-gh pr checkout <PR_NUMBER>
+gh pr checkout 196
 ```
 
 Or fetch it with Git:
 
 ```shell
-git fetch https://github.com/GingerPrivacy/GingerWallet.git pull/<PR_NUMBER>/head:trezor-suite-ginger-poc
+git fetch https://github.com/GingerPrivacy/GingerWallet.git pull/196/head:trezor-suite-ginger-poc
 git switch trezor-suite-ginger-poc
 ```
 

--- a/WalletWasabi.Fluent/Settings/ViewModels/SettingsPageViewModel.cs
+++ b/WalletWasabi.Fluent/Settings/ViewModels/SettingsPageViewModel.cs
@@ -41,6 +41,7 @@ public partial class SettingsPageViewModel : RoutableViewModel
 		AppearanceSettingsTab = new AppearanceSettingsTabViewModel(UiContext.ApplicationSettings);
 		BitcoinTabSettings = new BitcoinTabSettingsViewModel(UiContext.ApplicationSettings);
 		SecuritySettingsTab = new SecuritySettingsTabViewModel(UiContext.ApplicationSettings);
+		TrezorSuiteSettingsTab = new TrezorSuiteSettingsTabViewModel();
 
 		RestartCommand = ReactiveCommand.Create(() => AppLifetimeHelper.Shutdown(withShutdownPrevention: true, restart: true));
 		NextCommand = CancelCommand;
@@ -68,6 +69,7 @@ public partial class SettingsPageViewModel : RoutableViewModel
 	public AppearanceSettingsTabViewModel AppearanceSettingsTab { get; }
 	public BitcoinTabSettingsViewModel BitcoinTabSettings { get; }
 	public SecuritySettingsTabViewModel SecuritySettingsTab { get; }
+	public TrezorSuiteSettingsTabViewModel TrezorSuiteSettingsTab { get; }
 
 	public Task Activate()
 	{

--- a/WalletWasabi.Fluent/Settings/ViewModels/TrezorSuiteSettingsTabViewModel.cs
+++ b/WalletWasabi.Fluent/Settings/ViewModels/TrezorSuiteSettingsTabViewModel.cs
@@ -1,0 +1,168 @@
+using System;
+using System.Globalization;
+using System.Reactive;
+using System.Threading.Tasks;
+using ReactiveUI;
+using WalletWasabi.Fluent.Helpers;
+using WalletWasabi.Fluent.Infrastructure;
+using WalletWasabi.Fluent.Models;
+using WalletWasabi.Fluent.Navigation.ViewModels;
+using WalletWasabi.Logging;
+using WalletWasabi.TrezorSuite;
+
+namespace WalletWasabi.Fluent.Settings.ViewModels;
+
+[AppLifetime]
+[NavigationMetaData(
+	Order = 5,
+	Category = SearchCategory.Settings,
+	IconName = "settings_general_regular",
+	IsLocalized = false)]
+public partial class TrezorSuiteSettingsTabViewModel : RoutableViewModel
+{
+	private readonly TrezorSuiteIntegrationService _integrationService;
+	private string? _lastConfigurationError;
+
+	[AutoNotify] private string _suiteExecutablePath = "";
+	[AutoNotify] private string _suiteStatus = "Checking…";
+	[AutoNotify] private string _suiteVersion = "Unknown";
+	[AutoNotify] private string _backendStatus = "Checking…";
+	[AutoNotify] private string _configurationStatus = "Checking…";
+	[AutoNotify] private string _lastVerified = "Never";
+	[AutoNotify] private string _statusMessage = "Checking Trezor Suite and Ginger backend…";
+	[AutoNotify] private bool _isConfigured;
+	[AutoNotify] private bool _canRestore;
+	[AutoNotify] private string _configureButtonText = "Configure and open Trezor Suite";
+
+	public TrezorSuiteSettingsTabViewModel()
+		: this(new TrezorSuiteIntegrationService(Services.DataDir))
+	{
+	}
+
+	internal TrezorSuiteSettingsTabViewModel(TrezorSuiteIntegrationService integrationService)
+	{
+		_integrationService = integrationService;
+
+		RefreshCommand = ReactiveCommand.CreateFromTask(RefreshAsync);
+		ChooseExecutableCommand = ReactiveCommand.CreateFromTask(ChooseExecutableAsync);
+		ConfigureAndLaunchCommand = ReactiveCommand.CreateFromTask(ConfigureAndLaunchAsync);
+		LaunchCommand = ReactiveCommand.CreateFromTask(LaunchAsync);
+		RestoreCommand = ReactiveCommand.CreateFromTask(RestoreAsync);
+
+		EnableAutoBusyOn(
+			RefreshCommand,
+			ChooseExecutableCommand,
+			ConfigureAndLaunchCommand,
+			LaunchCommand,
+			RestoreCommand);
+
+		RefreshCommand.Execute().Subscribe();
+	}
+
+	public ReactiveCommand<Unit, Unit> RefreshCommand { get; }
+	public ReactiveCommand<Unit, Unit> ChooseExecutableCommand { get; }
+	public ReactiveCommand<Unit, Unit> ConfigureAndLaunchCommand { get; }
+	public ReactiveCommand<Unit, Unit> LaunchCommand { get; }
+	public ReactiveCommand<Unit, Unit> RestoreCommand { get; }
+
+	private async Task RefreshAsync()
+	{
+		try
+		{
+			ApplyStatus(await _integrationService.GetStatusAsync(SuiteExecutablePath));
+		}
+		catch (Exception ex)
+		{
+			Logger.LogError(ex);
+			StatusMessage = $"Status check failed: {ex.Message}";
+		}
+	}
+
+	private async Task ChooseExecutableAsync()
+	{
+		var file = await FileDialogHelper.OpenFileAsync("Select the Trezor Suite executable", ["*"]);
+		if (file is null)
+		{
+			return;
+		}
+
+		SuiteExecutablePath = file.Path.LocalPath;
+		await RefreshAsync();
+	}
+
+	private async Task ConfigureAndLaunchAsync()
+	{
+		try
+		{
+			_lastConfigurationError = null;
+			StatusMessage = "Configuring Trezor Suite for Ginger CoinJoin…";
+			ApplyStatus(await _integrationService.ConfigureAndLaunchAsync(SuiteExecutablePath));
+			StatusMessage = "Trezor Suite opened with Ginger CoinJoin configured.";
+		}
+		catch (Exception ex)
+		{
+			_lastConfigurationError = ex.Message;
+			ConfigurationStatus = "Configuration failed";
+			await HandleOperationErrorAsync(ex);
+		}
+	}
+
+	private async Task LaunchAsync()
+	{
+		try
+		{
+			_integrationService.Launch(SuiteExecutablePath);
+			StatusMessage = "Trezor Suite opened.";
+		}
+		catch (Exception ex)
+		{
+			await HandleOperationErrorAsync(ex);
+		}
+	}
+
+	private async Task RestoreAsync()
+	{
+		try
+		{
+			StatusMessage = "Restoring the original Trezor Suite configuration…";
+			ApplyStatus(await _integrationService.RestoreAndLaunchAsync(SuiteExecutablePath));
+			_lastConfigurationError = null;
+			StatusMessage = "The original Trezor Suite configuration was restored and Suite was opened.";
+		}
+		catch (Exception ex)
+		{
+			await HandleOperationErrorAsync(ex);
+		}
+	}
+
+	private void ApplyStatus(TrezorSuiteIntegrationStatus status)
+	{
+		if (!string.IsNullOrWhiteSpace(status.ExecutablePath))
+		{
+			SuiteExecutablePath = status.ExecutablePath;
+		}
+
+		SuiteStatus = status.IsInstalled ? "Installed" : "Not found";
+		SuiteVersion = status.SuiteVersion ?? "Unknown";
+		BackendStatus = status.IsBackendAvailable ? "Online" : "Unavailable";
+		ConfigurationStatus = status.IsConfigured ? "Configured for Ginger" : "Not configured";
+		LastVerified = status.LastVerifiedAt?.ToLocalTime().ToString("g", CultureInfo.CurrentCulture) ?? "Never";
+		IsConfigured = status.IsConfigured;
+		CanRestore = status.HasBackup;
+		ConfigureButtonText = status.IsConfigured ? "Repair and open Trezor Suite" : "Configure and open Trezor Suite";
+		StatusMessage = status.Message;
+
+		if (!status.IsConfigured && _lastConfigurationError is { } error)
+		{
+			ConfigurationStatus = "Configuration failed";
+			StatusMessage = $"Last configuration attempt failed: {error}";
+		}
+	}
+
+	private async Task HandleOperationErrorAsync(Exception exception)
+	{
+		Logger.LogError(exception);
+		StatusMessage = exception.Message;
+		await ShowErrorAsync("Trezor Suite", exception.Message, "Ginger could not configure Trezor Suite.");
+	}
+}

--- a/WalletWasabi.Fluent/Settings/ViewModels/TrezorSuiteSettingsTabViewModel.cs
+++ b/WalletWasabi.Fluent/Settings/ViewModels/TrezorSuiteSettingsTabViewModel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Globalization;
+using System.IO;
 using System.Reactive;
 using System.Threading.Tasks;
 using ReactiveUI;
@@ -48,13 +49,15 @@ public partial class TrezorSuiteSettingsTabViewModel : RoutableViewModel
 		ConfigureAndLaunchCommand = ReactiveCommand.CreateFromTask(ConfigureAndLaunchAsync);
 		LaunchCommand = ReactiveCommand.CreateFromTask(LaunchAsync);
 		RestoreCommand = ReactiveCommand.CreateFromTask(RestoreAsync);
+		OpenLogsCommand = ReactiveCommand.CreateFromTask(OpenLogsAsync);
 
 		EnableAutoBusyOn(
 			RefreshCommand,
 			ChooseExecutableCommand,
 			ConfigureAndLaunchCommand,
 			LaunchCommand,
-			RestoreCommand);
+			RestoreCommand,
+			OpenLogsCommand);
 
 		RefreshCommand.Execute().Subscribe();
 	}
@@ -64,6 +67,8 @@ public partial class TrezorSuiteSettingsTabViewModel : RoutableViewModel
 	public ReactiveCommand<Unit, Unit> ConfigureAndLaunchCommand { get; }
 	public ReactiveCommand<Unit, Unit> LaunchCommand { get; }
 	public ReactiveCommand<Unit, Unit> RestoreCommand { get; }
+	public ReactiveCommand<Unit, Unit> OpenLogsCommand { get; }
+	public string LogDirectoryPath => _integrationService.LogDirectoryPath;
 
 	private async Task RefreshAsync()
 	{
@@ -132,6 +137,20 @@ public partial class TrezorSuiteSettingsTabViewModel : RoutableViewModel
 		catch (Exception ex)
 		{
 			await HandleOperationErrorAsync(ex);
+		}
+	}
+
+	private async Task OpenLogsAsync()
+	{
+		try
+		{
+			Directory.CreateDirectory(LogDirectoryPath);
+			UiContext.FileSystem.OpenFolderInFileExplorer(LogDirectoryPath);
+		}
+		catch (Exception ex)
+		{
+			Logger.LogError(ex);
+			await ShowErrorAsync("Trezor Suite logs", ex.Message, "Ginger could not open the Trezor Suite log folder.");
 		}
 	}
 

--- a/WalletWasabi.Fluent/Settings/Views/SettingsPageView.axaml
+++ b/WalletWasabi.Fluent/Settings/Views/SettingsPageView.axaml
@@ -66,6 +66,12 @@
                                            IsEnabled="{Binding !IsReadOnly}" />
           </ScrollViewer>
         </TabItem>
+
+        <TabItem Header="Trezor">
+          <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
+            <views:TrezorSuiteSettingsTabView DataContext="{Binding TrezorSuiteSettingsTab}" />
+          </ScrollViewer>
+        </TabItem>
       </TabControl>
     </DockPanel>
   </ContentArea>

--- a/WalletWasabi.Fluent/Settings/Views/TrezorSuiteSettingsTabView.axaml
+++ b/WalletWasabi.Fluent/Settings/Views/TrezorSuiteSettingsTabView.axaml
@@ -62,6 +62,23 @@
       </DockPanel>
     </DockPanel>
 
+    <DockPanel>
+      <TextBlock Text="Trezor Suite diagnostic logs" />
+      <DockPanel>
+        <Button Content="Open folder"
+                Command="{Binding OpenLogsCommand}"
+                Margin="8 0 0 0"
+                DockPanel.Dock="Right" />
+        <TextBox Text="{Binding LogDirectoryPath}"
+                 IsReadOnly="True"
+                 HorizontalContentAlignment="Left" />
+      </DockPanel>
+    </DockPanel>
+
+    <TextBlock Text="Suite is launched with debug file logging for this experiment. Logs may contain wallet metadata; review and redact them before sharing."
+               TextWrapping="Wrap"
+               Opacity="0.72" />
+
     <InfoMessage>
       <TextBlock Text="{Binding StatusMessage}" TextWrapping="Wrap" />
     </InfoMessage>

--- a/WalletWasabi.Fluent/Settings/Views/TrezorSuiteSettingsTabView.axaml
+++ b/WalletWasabi.Fluent/Settings/Views/TrezorSuiteSettingsTabView.axaml
@@ -1,0 +1,90 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:viewModels="clr-namespace:WalletWasabi.Fluent.Settings.ViewModels"
+             mc:Ignorable="d"
+             d:DesignWidth="650"
+             x:DataType="viewModels:TrezorSuiteSettingsTabViewModel"
+             x:Class="WalletWasabi.Fluent.Settings.Views.TrezorSuiteSettingsTabView"
+             x:CompileBindings="True">
+
+  <StackPanel Classes="settingsLayout">
+    <Border Padding="16"
+            CornerRadius="8"
+            Background="{DynamicResource Layer1BackgroundBrush}">
+      <StackPanel Spacing="8">
+        <TextBlock Text="Experimental Trezor Suite CoinJoin integration"
+                   FontWeight="SemiBold" />
+        <TextBlock Text="Ginger briefly starts Trezor Suite in local configuration mode, backs up its existing debug settings, applies the Ginger coordinator override, verifies it, and then opens Suite normally. Ginger does not monitor Suite or handle your Trezor secrets."
+                   TextWrapping="Wrap" />
+        <TextBlock Text="Close Trezor Suite before configuring. Start with an empty or low-value test account until a complete hardware signing round has been verified."
+                   TextWrapping="Wrap"
+                   Opacity="0.72" />
+      </StackPanel>
+    </Border>
+
+    <DockPanel>
+      <TextBlock Text="Trezor Suite" />
+      <Label Content="{Binding SuiteStatus}" />
+    </DockPanel>
+
+    <DockPanel>
+      <TextBlock Text="Ginger CoinJoin backend" />
+      <Label Content="{Binding BackendStatus}" />
+    </DockPanel>
+
+    <DockPanel>
+      <TextBlock Text="Trezor Suite version" />
+      <Label Content="{Binding SuiteVersion}" />
+    </DockPanel>
+
+    <DockPanel>
+      <TextBlock Text="Configuration" />
+      <Label Content="{Binding ConfigurationStatus}" />
+    </DockPanel>
+
+    <DockPanel>
+      <TextBlock Text="Last verified" />
+      <Label Content="{Binding LastVerified}" />
+    </DockPanel>
+
+    <DockPanel>
+      <TextBlock Text="Trezor Suite executable" />
+      <DockPanel>
+        <Button Content="Choose…"
+                Command="{Binding ChooseExecutableCommand}"
+                Margin="8 0 0 0"
+                DockPanel.Dock="Right" />
+        <TextBox Text="{Binding SuiteExecutablePath}"
+                 IsReadOnly="True"
+                 HorizontalContentAlignment="Left" />
+      </DockPanel>
+    </DockPanel>
+
+    <InfoMessage>
+      <TextBlock Text="{Binding StatusMessage}" TextWrapping="Wrap" />
+    </InfoMessage>
+
+    <ProgressBar IsIndeterminate="True"
+                 IsVisible="{Binding IsBusy}"
+                 Height="4" />
+
+    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+      <Button Content="Refresh"
+              Command="{Binding RefreshCommand}" />
+      <Button Content="Restore original configuration"
+              Command="{Binding RestoreCommand}"
+              IsVisible="{Binding CanRestore}" />
+    </StackPanel>
+
+    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+      <Button Content="Open Trezor Suite"
+              Command="{Binding LaunchCommand}"
+              IsVisible="{Binding IsConfigured}" />
+      <Button Content="{Binding ConfigureButtonText}"
+              Theme="{StaticResource AccentButton}"
+              Command="{Binding ConfigureAndLaunchCommand}" />
+    </StackPanel>
+  </StackPanel>
+</UserControl>

--- a/WalletWasabi.Fluent/Settings/Views/TrezorSuiteSettingsTabView.axaml.cs
+++ b/WalletWasabi.Fluent/Settings/Views/TrezorSuiteSettingsTabView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace WalletWasabi.Fluent.Settings.Views;
+
+public class TrezorSuiteSettingsTabView : UserControl
+{
+	public TrezorSuiteSettingsTabView()
+	{
+		InitializeComponent();
+	}
+
+	private void InitializeComponent()
+	{
+		AvaloniaXamlLoader.Load(this);
+	}
+}

--- a/WalletWasabi.Tests/UnitTests/TrezorSuite/TrezorSuiteIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/TrezorSuite/TrezorSuiteIntegrationTests.cs
@@ -1,0 +1,99 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using WalletWasabi.TrezorSuite;
+using Xunit;
+
+namespace WalletWasabi.Tests.UnitTests.TrezorSuite;
+
+public class TrezorSuiteIntegrationTests
+{
+	[Fact]
+	public void LocatorPrefersExplicitExecutablePath()
+	{
+		var temporaryDirectory = Directory.CreateTempSubdirectory("ginger-trezor-locator-");
+		try
+		{
+			var preferredPath = Path.Combine(temporaryDirectory.FullName, "preferred-suite");
+			var previousPath = Path.Combine(temporaryDirectory.FullName, "previous-suite");
+			File.WriteAllText(preferredPath, "test");
+			File.WriteAllText(previousPath, "test");
+
+			var result = new TrezorSuiteLocator().Locate(preferredPath, previousPath);
+
+			Assert.Equal(Path.GetFullPath(preferredPath), result, TrezorSuiteLocator.PathComparer);
+		}
+		finally
+		{
+			temporaryDirectory.Delete(recursive: true);
+		}
+	}
+
+	[Fact]
+	public void ApplyScriptContainsCompleteGingerOverride()
+	{
+		var script = TrezorSuiteCdpClient.BuildApplyOverrideScript();
+
+		Assert.Contains("https://api.gingerwallet.io/WabiSabi/", script, StringComparison.Ordinal);
+		Assert.Contains("https://api.gingerwallet.io/", script, StringComparison.Ordinal);
+		Assert.Contains("affiliationId: null", script, StringComparison.Ordinal);
+		Assert.Contains("coinjoinDebugSettings", script, StringComparison.Ordinal);
+		Assert.Contains("put(value, 'debug')", script, StringComparison.Ordinal);
+		Assert.DoesNotContain("try {\n\t\t\t\t\t{", script, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void RestoreScriptPreservesSerializedOriginalValue()
+	{
+		const string OriginalJson = "{\"coinjoinServerEnvironment\":{\"btc\":\"staging\"},\"note\":\"'quoted'\"}";
+
+		var script = TrezorSuiteCdpClient.BuildRestoreSettingsScript(true, OriginalJson);
+
+		Assert.Contains("const originallyExisted = true", script, StringComparison.Ordinal);
+		Assert.Contains("JSON.parse(\"{\\u0022coinjoinServerEnvironment", script, StringComparison.Ordinal);
+		Assert.Contains("writeDebugSettings(db, original)", script, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public async Task StatusReportsDetectedSuiteAndAvailableBackendAsync()
+	{
+		var temporaryDirectory = Directory.CreateTempSubdirectory("ginger-trezor-status-");
+		try
+		{
+			var executablePath = Path.Combine(temporaryDirectory.FullName, "trezor-suite");
+			File.WriteAllText(executablePath, "test");
+			using var handler = new SuccessfulBackendHandler();
+			#pragma warning disable RS0030 // A controlled test handler requires constructing its client directly.
+			using var httpClient = new HttpClient(handler, disposeHandler: false);
+			#pragma warning restore RS0030
+			using var service = new TrezorSuiteIntegrationService(temporaryDirectory.FullName, httpClient);
+
+			var status = await service.GetStatusAsync(executablePath);
+
+			Assert.True(status.IsInstalled);
+			Assert.True(status.IsBackendAvailable);
+			Assert.False(status.IsConfigured);
+			Assert.False(status.HasBackup);
+			Assert.Equal(Path.GetFullPath(executablePath), status.ExecutablePath, TrezorSuiteLocator.PathComparer);
+		}
+		finally
+		{
+			temporaryDirectory.Delete(recursive: true);
+		}
+	}
+
+	private sealed class SuccessfulBackendHandler : HttpMessageHandler
+	{
+		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+		{
+			return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+			{
+				RequestMessage = request,
+				Content = new StringContent("{}")
+			});
+		}
+	}
+}

--- a/WalletWasabi.Tests/UnitTests/TrezorSuite/TrezorSuiteIntegrationTests.cs
+++ b/WalletWasabi.Tests/UnitTests/TrezorSuite/TrezorSuiteIntegrationTests.cs
@@ -66,9 +66,9 @@ public class TrezorSuiteIntegrationTests
 			var executablePath = Path.Combine(temporaryDirectory.FullName, "trezor-suite");
 			File.WriteAllText(executablePath, "test");
 			using var handler = new SuccessfulBackendHandler();
-			#pragma warning disable RS0030 // A controlled test handler requires constructing its client directly.
+#pragma warning disable RS0030 // A controlled test handler requires constructing its client directly.
 			using var httpClient = new HttpClient(handler, disposeHandler: false);
-			#pragma warning restore RS0030
+#pragma warning restore RS0030
 			using var service = new TrezorSuiteIntegrationService(temporaryDirectory.FullName, httpClient);
 
 			var status = await service.GetStatusAsync(executablePath);
@@ -83,6 +83,43 @@ public class TrezorSuiteIntegrationTests
 		{
 			temporaryDirectory.Delete(recursive: true);
 		}
+	}
+
+	[Fact]
+	public void SuiteLaunchArgumentsEnableDiagnosticFileLogging()
+	{
+		var temporaryDirectory = Directory.CreateTempSubdirectory("ginger-trezor-logs-");
+		try
+		{
+			using var service = new TrezorSuiteIntegrationService(temporaryDirectory.FullName);
+
+			var arguments = service.GetLaunchArguments();
+
+			Assert.Contains("--log-write", arguments);
+			Assert.Contains("--log-level=debug", arguments);
+			Assert.Contains("--log-file=trezor-suite-log-%ts.txt", arguments);
+			Assert.Contains($"--log-path={service.LogDirectoryPath}", arguments);
+			Assert.Equal(
+				Path.Combine(temporaryDirectory.FullName, "TrezorSuiteIntegration", "SuiteLogs"),
+				service.LogDirectoryPath);
+		}
+		finally
+		{
+			temporaryDirectory.Delete(recursive: true);
+		}
+	}
+
+	[Fact]
+	public void BootstrapArgumentsIncludeDiagnosticFileLogging()
+	{
+		using var service = new TrezorSuiteIntegrationService(Path.GetTempPath());
+
+		var arguments = service.GetBootstrapArguments(12345);
+
+		Assert.Contains("--log-write", arguments);
+		Assert.Contains("--log-level=debug", arguments);
+		Assert.Contains("--remote-debugging-address=127.0.0.1", arguments);
+		Assert.Contains("--remote-debugging-port=12345", arguments);
 	}
 
 	private sealed class SuccessfulBackendHandler : HttpMessageHandler

--- a/WalletWasabi/TrezorSuite/TrezorSuiteCdpClient.cs
+++ b/WalletWasabi/TrezorSuite/TrezorSuiteCdpClient.cs
@@ -1,0 +1,343 @@
+using System;
+using System.Buffers;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using WalletWasabi.WebClients.Wasabi;
+
+namespace WalletWasabi.TrezorSuite;
+
+internal sealed class TrezorSuiteCdpClient : IAsyncDisposable
+{
+	private readonly ClientWebSocket _webSocket = new();
+	private int _messageId;
+
+	private TrezorSuiteCdpClient()
+	{
+	}
+
+	public static async Task<TrezorSuiteCdpClient> ConnectAsync(int port, TimeSpan timeout, CancellationToken cancellationToken)
+	{
+		using var timeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+		timeoutSource.CancelAfter(timeout);
+
+		using var httpClient = WasabiHttpClientFactory.CreateLongLivedHttpClient();
+		httpClient.BaseAddress = new Uri($"http://127.0.0.1:{port}/");
+		httpClient.Timeout = TimeSpan.FromSeconds(2);
+
+		Exception? lastException = null;
+		while (!timeoutSource.IsCancellationRequested)
+		{
+			try
+			{
+				using var response = await httpClient.GetAsync("json/list", timeoutSource.Token).ConfigureAwait(false);
+				response.EnsureSuccessStatusCode();
+				await using var responseStream = await response.Content.ReadAsStreamAsync(timeoutSource.Token).ConfigureAwait(false);
+				using var document = await JsonDocument.ParseAsync(responseStream, cancellationToken: timeoutSource.Token).ConfigureAwait(false);
+
+				var target = document.RootElement
+					.EnumerateArray()
+					.Where(x => x.TryGetProperty("type", out var type) && type.GetString() == "page")
+					.Where(x => !x.TryGetProperty("url", out var url) || !IsDevToolsUrl(url.GetString()))
+					.FirstOrDefault(x => x.TryGetProperty("webSocketDebuggerUrl", out _));
+
+				if (target.ValueKind != JsonValueKind.Undefined &&
+					target.TryGetProperty("webSocketDebuggerUrl", out var webSocketUrl) &&
+					Uri.TryCreate(webSocketUrl.GetString(), UriKind.Absolute, out var uri))
+				{
+					var client = new TrezorSuiteCdpClient();
+					await client._webSocket.ConnectAsync(uri, timeoutSource.Token).ConfigureAwait(false);
+					return client;
+				}
+			}
+			catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or JsonException)
+			{
+				lastException = ex;
+			}
+
+			try
+			{
+				await Task.Delay(250, timeoutSource.Token).ConfigureAwait(false);
+			}
+			catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+			{
+				break;
+			}
+		}
+
+		cancellationToken.ThrowIfCancellationRequested();
+
+		throw new TrezorSuiteIntegrationException(
+			"Trezor Suite did not expose its local configuration target. Close every running Trezor Suite window and try again.",
+			lastException ?? new TimeoutException());
+	}
+
+	public async Task<TrezorSuiteStoredSettings> ReadDebugSettingsAsync(CancellationToken cancellationToken)
+	{
+		var value = await EvaluateAsync(BuildReadSettingsScript(), cancellationToken).ConfigureAwait(false);
+		return new TrezorSuiteStoredSettings(
+			value.GetProperty("exists").GetBoolean(),
+			value.GetProperty("json").ValueKind == JsonValueKind.Null ? null : value.GetProperty("json").GetString());
+	}
+
+	public async Task ApplyGingerOverrideAsync(CancellationToken cancellationToken)
+	{
+		var value = await EvaluateAsync(BuildApplyOverrideScript(), cancellationToken).ConfigureAwait(false);
+		if (!value.GetProperty("configured").GetBoolean())
+		{
+			throw new TrezorSuiteIntegrationException("Trezor Suite did not retain the Ginger CoinJoin configuration override.");
+		}
+	}
+
+	public async Task RestoreDebugSettingsAsync(bool originalSettingsExisted, string? originalSettingsJson, CancellationToken cancellationToken)
+	{
+		var value = await EvaluateAsync(BuildRestoreSettingsScript(originalSettingsExisted, originalSettingsJson), cancellationToken).ConfigureAwait(false);
+		if (!value.GetProperty("restored").GetBoolean())
+		{
+			throw new TrezorSuiteIntegrationException("Trezor Suite did not restore its original CoinJoin debug settings.");
+		}
+	}
+
+	public async ValueTask DisposeAsync()
+	{
+		if (_webSocket.State is WebSocketState.Open or WebSocketState.CloseReceived)
+		{
+			using var timeoutSource = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+			try
+			{
+				await _webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Configuration complete", timeoutSource.Token).ConfigureAwait(false);
+			}
+			catch (Exception) when (timeoutSource.IsCancellationRequested)
+			{
+			}
+		}
+
+		_webSocket.Dispose();
+	}
+
+	internal static string BuildReadSettingsScript() => $$"""
+		(async () => {
+			{{DatabaseHelpers}}
+			const db = await openSuiteDatabase();
+			const value = await readDebugSettings(db);
+			db.close();
+			return { exists: value !== undefined, json: value === undefined ? null : JSON.stringify(value) };
+		})()
+		""";
+
+	internal static string BuildApplyOverrideScript() => $$"""
+		(async () => {
+			{{DatabaseHelpers}}
+			const db = await openSuiteDatabase();
+			const current = (await readDebugSettings(db)) ?? {};
+			const overrides = current.coinjoinConfigOverride ?? {};
+			const btc = overrides.btc ?? {};
+			const updated = {
+				...current,
+				coinjoinConfigOverride: {
+					...overrides,
+					btc: {
+						...btc,
+						coordinatorUrl: 'https://api.gingerwallet.io/WabiSabi/',
+						wabisabiBackendUrl: 'https://api.gingerwallet.io/',
+						affiliationId: null
+					}
+				}
+			};
+			await writeDebugSettings(db, updated);
+			const saved = await readDebugSettings(db);
+			db.close();
+			const savedBtc = saved?.coinjoinConfigOverride?.btc;
+			return {
+				configured:
+					savedBtc?.coordinatorUrl === 'https://api.gingerwallet.io/WabiSabi/' &&
+					savedBtc?.wabisabiBackendUrl === 'https://api.gingerwallet.io/' &&
+					savedBtc?.affiliationId === null
+			};
+		})()
+		""";
+
+	internal static string BuildRestoreSettingsScript(bool originalSettingsExisted, string? originalSettingsJson)
+	{
+		var existed = originalSettingsExisted ? "true" : "false";
+		var serializedJson = JsonSerializer.Serialize(originalSettingsJson);
+
+		return $$"""
+			(async () => {
+				{{DatabaseHelpers}}
+				const db = await openSuiteDatabase();
+				const originallyExisted = {{existed}};
+				if (originallyExisted) {
+					const original = JSON.parse({{serializedJson}});
+					await writeDebugSettings(db, original);
+				} else {
+					await deleteDebugSettings(db);
+				}
+				const restoredValue = await readDebugSettings(db);
+				db.close();
+				return {
+					restored: originallyExisted
+						? JSON.stringify(restoredValue) === {{serializedJson}}
+						: restoredValue === undefined
+				};
+			})()
+			""";
+	}
+
+	private static bool IsDevToolsUrl(string? url) =>
+		url?.StartsWith("devtools://", StringComparison.OrdinalIgnoreCase) is true ||
+		url?.StartsWith("chrome-devtools://", StringComparison.OrdinalIgnoreCase) is true;
+
+	private async Task<JsonElement> EvaluateAsync(string expression, CancellationToken cancellationToken)
+	{
+		var messageId = Interlocked.Increment(ref _messageId);
+		var payload = JsonSerializer.Serialize(new
+		{
+			id = messageId,
+			method = "Runtime.evaluate",
+			@params = new
+			{
+				expression,
+				awaitPromise = true,
+				returnByValue = true
+			}
+		});
+
+		await _webSocket.SendAsync(
+			Encoding.UTF8.GetBytes(payload),
+			WebSocketMessageType.Text,
+			endOfMessage: true,
+			cancellationToken).ConfigureAwait(false);
+
+		while (true)
+		{
+			using var document = await ReceiveDocumentAsync(cancellationToken).ConfigureAwait(false);
+			if (!document.RootElement.TryGetProperty("id", out var id) || id.GetInt32() != messageId)
+			{
+				continue;
+			}
+
+			if (document.RootElement.TryGetProperty("error", out var protocolError))
+			{
+				throw new TrezorSuiteIntegrationException($"Trezor Suite configuration protocol failed: {protocolError}");
+			}
+
+			var result = document.RootElement.GetProperty("result");
+			if (result.TryGetProperty("exceptionDetails", out var exceptionDetails))
+			{
+				throw new TrezorSuiteIntegrationException(
+					$"Trezor Suite rejected the configuration update: {GetExceptionDescription(exceptionDetails)}");
+			}
+
+			return result.GetProperty("result").GetProperty("value").Clone();
+		}
+	}
+
+	private static string GetExceptionDescription(JsonElement exceptionDetails)
+	{
+		if (exceptionDetails.TryGetProperty("exception", out var exception) &&
+			exception.TryGetProperty("description", out var description) &&
+			!string.IsNullOrWhiteSpace(description.GetString()))
+		{
+			return description.GetString()!;
+		}
+
+		if (exceptionDetails.TryGetProperty("text", out var text) &&
+			!string.IsNullOrWhiteSpace(text.GetString()))
+		{
+			return text.GetString()!;
+		}
+
+		return "Unknown browser error.";
+	}
+
+	private async Task<JsonDocument> ReceiveDocumentAsync(CancellationToken cancellationToken)
+	{
+		var buffer = ArrayPool<byte>.Shared.Rent(8192);
+		try
+		{
+			using var stream = new MemoryStream();
+			while (true)
+			{
+				var result = await _webSocket.ReceiveAsync(buffer, cancellationToken).ConfigureAwait(false);
+				if (result.MessageType == WebSocketMessageType.Close)
+				{
+					throw new TrezorSuiteIntegrationException("Trezor Suite closed its configuration channel unexpectedly.");
+				}
+
+				stream.Write(buffer, 0, result.Count);
+				if (result.EndOfMessage)
+				{
+					stream.Position = 0;
+					return await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken).ConfigureAwait(false);
+				}
+			}
+		}
+		finally
+		{
+			ArrayPool<byte>.Shared.Return(buffer);
+		}
+	}
+
+	private const string DatabaseHelpers = """
+		const delay = milliseconds => new Promise(resolve => setTimeout(resolve, milliseconds));
+		const openSuiteDatabaseOnce = () => new Promise((resolve, reject) => {
+			const request = indexedDB.open('trezor-suite');
+			request.onsuccess = () => {
+				const db = request.result;
+				if (!db.objectStoreNames.contains('coinjoinDebugSettings')) {
+					db.close();
+					reject(new Error('Trezor Suite storage is not initialized yet.'));
+					return;
+				}
+				resolve(db);
+			};
+			request.onerror = () => reject(request.error);
+			request.onblocked = () => reject(new Error('Trezor Suite storage is busy.'));
+		});
+		const openSuiteDatabase = async () => {
+			for (let attempt = 0; attempt < 40; attempt++) {
+				const databases = await indexedDB.databases();
+				if (databases.some(database => database.name === 'trezor-suite')) {
+					try {
+						return await openSuiteDatabaseOnce();
+					}
+					catch (error) {
+						if (attempt === 39) {
+							throw error;
+						}
+					}
+				}
+
+				await delay(250);
+			}
+
+			throw new Error('Trezor Suite storage is not initialized yet.');
+		};
+		const readDebugSettings = db => new Promise((resolve, reject) => {
+			const request = db.transaction('coinjoinDebugSettings', 'readonly')
+				.objectStore('coinjoinDebugSettings').get('debug');
+			request.onsuccess = () => resolve(request.result);
+			request.onerror = () => reject(request.error);
+		});
+		const writeDebugSettings = (db, value) => new Promise((resolve, reject) => {
+			const transaction = db.transaction('coinjoinDebugSettings', 'readwrite');
+			transaction.objectStore('coinjoinDebugSettings').put(value, 'debug');
+			transaction.oncomplete = () => resolve();
+			transaction.onerror = () => reject(transaction.error);
+			transaction.onabort = () => reject(transaction.error);
+		});
+		const deleteDebugSettings = db => new Promise((resolve, reject) => {
+			const transaction = db.transaction('coinjoinDebugSettings', 'readwrite');
+			transaction.objectStore('coinjoinDebugSettings').delete('debug');
+			transaction.oncomplete = () => resolve();
+			transaction.onerror = () => reject(transaction.error);
+			transaction.onabort = () => reject(transaction.error);
+		});
+		""";
+}

--- a/WalletWasabi/TrezorSuite/TrezorSuiteIntegrationModels.cs
+++ b/WalletWasabi/TrezorSuite/TrezorSuiteIntegrationModels.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace WalletWasabi.TrezorSuite;
+
+public sealed record TrezorSuiteIntegrationStatus(
+	string? ExecutablePath,
+	string? SuiteVersion,
+	bool IsInstalled,
+	bool IsBackendAvailable,
+	bool IsConfigured,
+	bool HasBackup,
+	DateTimeOffset? LastVerifiedAt,
+	string Message);
+
+public sealed record TrezorSuiteIntegrationState(
+	string SuiteExecutablePath,
+	bool OriginalSettingsExisted,
+	string? OriginalSettingsJson,
+	DateTimeOffset? LastVerifiedAt);
+
+internal sealed record TrezorSuiteStoredSettings(bool Exists, string? Json);
+
+public sealed class TrezorSuiteIntegrationException : Exception
+{
+	public TrezorSuiteIntegrationException(string message)
+		: base(message)
+	{
+	}
+
+	public TrezorSuiteIntegrationException(string message, Exception innerException)
+		: base(message, innerException)
+	{
+	}
+}

--- a/WalletWasabi/TrezorSuite/TrezorSuiteIntegrationService.cs
+++ b/WalletWasabi/TrezorSuite/TrezorSuiteIntegrationService.cs
@@ -26,11 +26,15 @@ public sealed class TrezorSuiteIntegrationService : IDisposable
 
 	public TrezorSuiteIntegrationService(string gingerDataDir, HttpClient? httpClient = null, TrezorSuiteLocator? locator = null)
 	{
-		_stateFilePath = Path.Combine(gingerDataDir, "TrezorSuiteIntegration", "state.json");
+		var integrationDataDir = Path.Combine(gingerDataDir, "TrezorSuiteIntegration");
+		_stateFilePath = Path.Combine(integrationDataDir, "state.json");
+		LogDirectoryPath = Path.Combine(integrationDataDir, "SuiteLogs");
 		_httpClient = httpClient ?? WasabiHttpClientFactory.CreateLongLivedHttpClient();
 		_ownsHttpClient = httpClient is null;
 		_locator = locator ?? new TrezorSuiteLocator();
 	}
+
+	public string LogDirectoryPath { get; }
 
 	public async Task<TrezorSuiteIntegrationStatus> GetStatusAsync(string? preferredPath = null, CancellationToken cancellationToken = default)
 	{
@@ -116,7 +120,7 @@ public sealed class TrezorSuiteIntegrationService : IDisposable
 			}
 
 			await StopBootstrapProcessAsync(bootstrapProcess).ConfigureAwait(false);
-			StartSuite(executablePath, Array.Empty<string>()).Dispose();
+			StartSuite(executablePath, GetLaunchArguments()).Dispose();
 			return await GetStatusAsync(executablePath, cancellationToken).ConfigureAwait(false);
 		}
 		finally
@@ -154,7 +158,7 @@ public sealed class TrezorSuiteIntegrationService : IDisposable
 			}
 
 			File.Delete(_stateFilePath);
-			StartSuite(executablePath, Array.Empty<string>()).Dispose();
+			StartSuite(executablePath, GetLaunchArguments()).Dispose();
 			return await GetStatusAsync(executablePath, cancellationToken).ConfigureAwait(false);
 		}
 		finally
@@ -167,7 +171,7 @@ public sealed class TrezorSuiteIntegrationService : IDisposable
 	{
 		var state = LoadStateAsync(CancellationToken.None).GetAwaiter().GetResult();
 		var executablePath = RequireExecutablePath(preferredPath, state?.SuiteExecutablePath);
-		StartSuite(executablePath, Array.Empty<string>()).Dispose();
+		StartSuite(executablePath, GetLaunchArguments()).Dispose();
 	}
 
 	public void Dispose()
@@ -179,8 +183,17 @@ public sealed class TrezorSuiteIntegrationService : IDisposable
 		_operationLock.Dispose();
 	}
 
-	private static string[] GetBootstrapArguments(int port) =>
+	internal string[] GetLaunchArguments() =>
 	[
+		"--log-write",
+		"--log-level=debug",
+		$"--log-path={LogDirectoryPath}",
+		"--log-file=trezor-suite-log-%ts.txt"
+	];
+
+	internal string[] GetBootstrapArguments(int port) =>
+	[
+		.. GetLaunchArguments(),
 		"--open-devtools",
 		"--remote-debugging-address=127.0.0.1",
 		$"--remote-debugging-port={port}"

--- a/WalletWasabi/TrezorSuite/TrezorSuiteIntegrationService.cs
+++ b/WalletWasabi/TrezorSuite/TrezorSuiteIntegrationService.cs
@@ -1,0 +1,344 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using WalletWasabi.WebClients.Wasabi;
+
+namespace WalletWasabi.TrezorSuite;
+
+public sealed class TrezorSuiteIntegrationService : IDisposable
+{
+	private static readonly Uri GingerBackendUri = new("https://api.gingerwallet.io/");
+	private static readonly TimeSpan SuiteStartupTimeout = TimeSpan.FromSeconds(25);
+	private readonly HttpClient _httpClient;
+	private readonly bool _ownsHttpClient;
+	private readonly TrezorSuiteLocator _locator;
+	private readonly SemaphoreSlim _operationLock = new(1, 1);
+	private readonly string _stateFilePath;
+
+	public TrezorSuiteIntegrationService(string gingerDataDir, HttpClient? httpClient = null, TrezorSuiteLocator? locator = null)
+	{
+		_stateFilePath = Path.Combine(gingerDataDir, "TrezorSuiteIntegration", "state.json");
+		_httpClient = httpClient ?? WasabiHttpClientFactory.CreateLongLivedHttpClient();
+		_ownsHttpClient = httpClient is null;
+		_locator = locator ?? new TrezorSuiteLocator();
+	}
+
+	public async Task<TrezorSuiteIntegrationStatus> GetStatusAsync(string? preferredPath = null, CancellationToken cancellationToken = default)
+	{
+		var state = await LoadStateAsync(cancellationToken).ConfigureAwait(false);
+		var executablePath = _locator.Locate(preferredPath, state?.SuiteExecutablePath);
+		var backendAvailable = await IsBackendAvailableAsync(cancellationToken).ConfigureAwait(false);
+		var isConfigured = executablePath is not null &&
+			state?.LastVerifiedAt is not null &&
+			TrezorSuiteLocator.PathComparer.Equals(executablePath, state.SuiteExecutablePath);
+
+		var message = executablePath is null
+			? "Trezor Suite was not found. Select its executable to continue."
+			: !backendAvailable
+				? "Ginger's CoinJoin backend is currently unavailable."
+				: isConfigured
+					? "Ginger CoinJoin was configured and verified."
+					: "Trezor Suite is ready to be configured for Ginger CoinJoin.";
+
+		return new TrezorSuiteIntegrationStatus(
+			executablePath,
+			TryGetSuiteVersion(executablePath),
+			executablePath is not null,
+			backendAvailable,
+			isConfigured,
+			state is not null,
+			isConfigured ? state?.LastVerifiedAt : null,
+			message);
+	}
+
+	public async Task<TrezorSuiteIntegrationStatus> ConfigureAndLaunchAsync(string? preferredPath = null, CancellationToken cancellationToken = default)
+	{
+		await _operationLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+		try
+		{
+			var state = await LoadStateAsync(cancellationToken).ConfigureAwait(false);
+			var executablePath = RequireExecutablePath(preferredPath, state?.SuiteExecutablePath);
+
+			if (!await IsBackendAvailableAsync(cancellationToken).ConfigureAwait(false))
+			{
+				throw new TrezorSuiteIntegrationException("Ginger's CoinJoin backend is unavailable. Check your connection and try again.");
+			}
+
+			Process? bootstrapProcess = null;
+			var bootstrapStarted = false;
+			try
+			{
+				var port = GetUnusedLoopbackPort();
+				bootstrapProcess = StartSuite(executablePath, GetBootstrapArguments(port));
+				bootstrapStarted = true;
+
+				await using var cdpClient = await TrezorSuiteCdpClient.ConnectAsync(
+					port,
+					SuiteStartupTimeout,
+					cancellationToken).ConfigureAwait(false);
+
+				if (state is null)
+				{
+					var originalSettings = await cdpClient.ReadDebugSettingsAsync(cancellationToken).ConfigureAwait(false);
+					state = new TrezorSuiteIntegrationState(
+						executablePath,
+						originalSettings.Exists,
+						originalSettings.Json,
+						LastVerifiedAt: null);
+					await SaveStateAsync(state, cancellationToken).ConfigureAwait(false);
+				}
+
+				await cdpClient.ApplyGingerOverrideAsync(cancellationToken).ConfigureAwait(false);
+				state = state with
+				{
+					SuiteExecutablePath = executablePath,
+					LastVerifiedAt = DateTimeOffset.UtcNow
+				};
+				await SaveStateAsync(state, cancellationToken).ConfigureAwait(false);
+			}
+			catch
+			{
+				if (bootstrapStarted)
+				{
+					await StopBootstrapProcessAsync(bootstrapProcess).ConfigureAwait(false);
+				}
+
+				throw;
+			}
+
+			await StopBootstrapProcessAsync(bootstrapProcess).ConfigureAwait(false);
+			StartSuite(executablePath, Array.Empty<string>()).Dispose();
+			return await GetStatusAsync(executablePath, cancellationToken).ConfigureAwait(false);
+		}
+		finally
+		{
+			_operationLock.Release();
+		}
+	}
+
+	public async Task<TrezorSuiteIntegrationStatus> RestoreAndLaunchAsync(string? preferredPath = null, CancellationToken cancellationToken = default)
+	{
+		await _operationLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+		try
+		{
+			var state = await LoadStateAsync(cancellationToken).ConfigureAwait(false)
+				?? throw new TrezorSuiteIntegrationException("No original Trezor Suite configuration backup is available.");
+			var executablePath = RequireExecutablePath(preferredPath, state.SuiteExecutablePath);
+			Process? bootstrapProcess = null;
+
+			try
+			{
+				var port = GetUnusedLoopbackPort();
+				bootstrapProcess = StartSuite(executablePath, GetBootstrapArguments(port));
+				await using var cdpClient = await TrezorSuiteCdpClient.ConnectAsync(
+					port,
+					SuiteStartupTimeout,
+					cancellationToken).ConfigureAwait(false);
+				await cdpClient.RestoreDebugSettingsAsync(
+					state.OriginalSettingsExisted,
+					state.OriginalSettingsJson,
+					cancellationToken).ConfigureAwait(false);
+			}
+			finally
+			{
+				await StopBootstrapProcessAsync(bootstrapProcess).ConfigureAwait(false);
+			}
+
+			File.Delete(_stateFilePath);
+			StartSuite(executablePath, Array.Empty<string>()).Dispose();
+			return await GetStatusAsync(executablePath, cancellationToken).ConfigureAwait(false);
+		}
+		finally
+		{
+			_operationLock.Release();
+		}
+	}
+
+	public void Launch(string? preferredPath = null)
+	{
+		var state = LoadStateAsync(CancellationToken.None).GetAwaiter().GetResult();
+		var executablePath = RequireExecutablePath(preferredPath, state?.SuiteExecutablePath);
+		StartSuite(executablePath, Array.Empty<string>()).Dispose();
+	}
+
+	public void Dispose()
+	{
+		if (_ownsHttpClient)
+		{
+			_httpClient.Dispose();
+		}
+		_operationLock.Dispose();
+	}
+
+	private static string[] GetBootstrapArguments(int port) =>
+	[
+		"--open-devtools",
+		"--remote-debugging-address=127.0.0.1",
+		$"--remote-debugging-port={port}"
+	];
+
+	private static int GetUnusedLoopbackPort()
+	{
+		var listener = new TcpListener(IPAddress.Loopback, 0);
+		listener.Start();
+		try
+		{
+			return ((IPEndPoint)listener.LocalEndpoint).Port;
+		}
+		finally
+		{
+			listener.Stop();
+		}
+	}
+
+	private static Process StartSuite(string executablePath, string[] arguments)
+	{
+		var startInfo = new ProcessStartInfo(executablePath)
+		{
+			UseShellExecute = false,
+			CreateNoWindow = true
+		};
+
+		foreach (var argument in arguments)
+		{
+			startInfo.ArgumentList.Add(argument);
+		}
+
+		return Process.Start(startInfo)
+			?? throw new TrezorSuiteIntegrationException("Trezor Suite could not be started.");
+	}
+
+	private static async Task StopBootstrapProcessAsync(Process? process)
+	{
+		if (process is null)
+		{
+			return;
+		}
+
+		try
+		{
+			if (process.HasExited)
+			{
+				return;
+			}
+
+			if (OperatingSystem.IsWindows())
+			{
+				process.CloseMainWindow();
+			}
+			else
+			{
+				NativeMethods.SendSigTerm(process.Id);
+			}
+
+			using var timeoutSource = new CancellationTokenSource(TimeSpan.FromSeconds(8));
+			try
+			{
+				await process.WaitForExitAsync(timeoutSource.Token).ConfigureAwait(false);
+			}
+			catch (OperationCanceledException)
+			{
+				process.Kill(entireProcessTree: true);
+				await process.WaitForExitAsync().ConfigureAwait(false);
+			}
+		}
+		finally
+		{
+			process.Dispose();
+		}
+	}
+
+	private async Task<bool> IsBackendAvailableAsync(CancellationToken cancellationToken)
+	{
+		using var timeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+		timeoutSource.CancelAfter(TimeSpan.FromSeconds(10));
+
+		try
+		{
+			using var versionRequest = new HttpRequestMessage(HttpMethod.Get, new Uri(GingerBackendUri, "api/Software/versions"));
+			using var versionResponse = await _httpClient.SendAsync(versionRequest, timeoutSource.Token).ConfigureAwait(false);
+			if (!versionResponse.IsSuccessStatusCode)
+			{
+				return false;
+			}
+
+			using var statusRequest = new HttpRequestMessage(HttpMethod.Post, new Uri(GingerBackendUri, "WabiSabi/status"))
+			{
+				Content = new StringContent("{\"RoundCheckpoints\":[]}", Encoding.UTF8, MediaTypeHeaderValue.Parse("application/json"))
+			};
+			using var statusResponse = await _httpClient.SendAsync(statusRequest, timeoutSource.Token).ConfigureAwait(false);
+			return statusResponse.IsSuccessStatusCode;
+		}
+		catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+		{
+			return false;
+		}
+	}
+
+	private string RequireExecutablePath(string? preferredPath, string? previouslyUsedPath)
+	{
+		return _locator.Locate(preferredPath, previouslyUsedPath)
+			?? throw new TrezorSuiteIntegrationException("Trezor Suite was not found. Select the Trezor Suite executable and try again.");
+	}
+
+	private static string? TryGetSuiteVersion(string? executablePath)
+	{
+		if (executablePath is null)
+		{
+			return null;
+		}
+
+		try
+		{
+			var versionInfo = FileVersionInfo.GetVersionInfo(executablePath);
+			return string.IsNullOrWhiteSpace(versionInfo.ProductVersion)
+				? versionInfo.FileVersion
+				: versionInfo.ProductVersion;
+		}
+		catch (Exception ex) when (ex is FileNotFoundException or IOException or UnauthorizedAccessException)
+		{
+			return null;
+		}
+	}
+
+	private async Task<TrezorSuiteIntegrationState?> LoadStateAsync(CancellationToken cancellationToken)
+	{
+		if (!File.Exists(_stateFilePath))
+		{
+			return null;
+		}
+
+		await using var stream = File.OpenRead(_stateFilePath);
+		return await JsonSerializer.DeserializeAsync<TrezorSuiteIntegrationState>(stream, cancellationToken: cancellationToken).ConfigureAwait(false);
+	}
+
+	private async Task SaveStateAsync(TrezorSuiteIntegrationState state, CancellationToken cancellationToken)
+	{
+		var directory = Path.GetDirectoryName(_stateFilePath)!;
+		Directory.CreateDirectory(directory);
+		await using var stream = File.Create(_stateFilePath);
+		await JsonSerializer.SerializeAsync(stream, state, new JsonSerializerOptions { WriteIndented = true }, cancellationToken).ConfigureAwait(false);
+	}
+
+	private static class NativeMethods
+	{
+		private const int SigTerm = 15;
+
+		[DllImport("libc", EntryPoint = "kill", SetLastError = true)]
+		private static extern int Kill(int processId, int signal);
+
+		public static void SendSigTerm(int processId)
+		{
+			_ = Kill(processId, SigTerm);
+		}
+	}
+}

--- a/WalletWasabi/TrezorSuite/TrezorSuiteLocator.cs
+++ b/WalletWasabi/TrezorSuite/TrezorSuiteLocator.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace WalletWasabi.TrezorSuite;
+
+public sealed class TrezorSuiteLocator
+{
+	public string? Locate(string? preferredPath = null, string? previouslyUsedPath = null)
+	{
+		return EnumerateCandidates(preferredPath, previouslyUsedPath)
+			.FirstOrDefault(File.Exists);
+	}
+
+	public IEnumerable<string> EnumerateCandidates(string? preferredPath = null, string? previouslyUsedPath = null)
+	{
+		var candidates = new List<string>();
+
+		AddCandidate(candidates, preferredPath);
+		AddCandidate(candidates, previouslyUsedPath);
+
+		if (OperatingSystem.IsWindows())
+		{
+			AddWindowsCandidates(candidates);
+		}
+		else if (OperatingSystem.IsMacOS())
+		{
+			AddCandidate(candidates, "/Applications/Trezor Suite.app/Contents/MacOS/Trezor Suite");
+			AddCandidate(candidates, Path.Combine(
+				Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+				"Applications",
+				"Trezor Suite.app",
+				"Contents",
+				"MacOS",
+				"Trezor Suite"));
+		}
+		else if (OperatingSystem.IsLinux())
+		{
+			AddCandidate(candidates, "/usr/bin/trezor-suite");
+			AddCandidate(candidates, "/usr/local/bin/trezor-suite");
+			AddCandidate(candidates, "/opt/Trezor Suite/trezor-suite");
+			AddCandidate(candidates, "/opt/trezor-suite/trezor-suite");
+			AddPathCandidates(candidates, "trezor-suite", "Trezor-Suite");
+		}
+
+		return candidates.Distinct(PathComparer);
+	}
+
+	internal static StringComparer PathComparer => OperatingSystem.IsWindows()
+		? StringComparer.OrdinalIgnoreCase
+		: StringComparer.Ordinal;
+
+	private static void AddWindowsCandidates(ICollection<string> candidates)
+	{
+		var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+		var programFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+		var programFilesX86 = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
+
+		AddCandidate(candidates, Path.Combine(localAppData, "Programs", "Trezor Suite", "Trezor Suite.exe"));
+		AddCandidate(candidates, Path.Combine(programFiles, "Trezor Suite", "Trezor Suite.exe"));
+		AddCandidate(candidates, Path.Combine(programFilesX86, "Trezor Suite", "Trezor Suite.exe"));
+		AddPathCandidates(candidates, "Trezor Suite.exe");
+	}
+
+	private static void AddPathCandidates(ICollection<string> candidates, params string[] executableNames)
+	{
+		var path = Environment.GetEnvironmentVariable("PATH");
+		if (string.IsNullOrWhiteSpace(path))
+		{
+			return;
+		}
+
+		foreach (var directory in path.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+		{
+			foreach (var executableName in executableNames)
+			{
+				AddCandidate(candidates, Path.Combine(directory, executableName));
+			}
+		}
+	}
+
+	private static void AddCandidate(ICollection<string> candidates, string? candidate)
+	{
+		if (!string.IsNullOrWhiteSpace(candidate))
+		{
+			candidates.Add(Path.GetFullPath(candidate));
+		}
+	}
+}


### PR DESCRIPTION
## PoC goal

Explore whether the CoinJoin implementation still shipped inside Trezor Suite can use Ginger's WabiSabi coordinator after Trezor removed the supported CoinJoin GUI flow.

This is deliberately a **draft proof of concept**. A successful configuration means Suite retained and reread the Ginger override; it does not yet prove that every Suite version exposes CoinJoin controls or that a hardware-signed round completes.

## What this adds

- A new **Settings > Trezor** tab in Ginger.
- Windows, macOS, and Linux Trezor Suite executable discovery, plus manual selection.
- Ginger backend and coordinator reachability checks.
- A short-lived, random loopback Chrome DevTools Protocol session used to access Suite's existing IndexedDB debug configuration.
- Merge-preserving Bitcoin overrides:
  - `coordinatorUrl = https://api.gingerwallet.io/WabiSabi/`
  - `wabisabiBackendUrl = https://api.gingerwallet.io/`
  - `affiliationId = null`
- Read-back verification before Ginger reports `Configured for Ginger`.
- Exact backup and restoration of Suite's prior debug value.
- Clear distinction between detected/online prerequisites, a failed attempt, and a verified configuration.
- A cross-platform test guide and sanitized result template.

The full tutorial is in [TrezorSuiteGingerCoinJoinPoc.md](https://github.com/molnard/GingerWallet/blob/feature/trezor-suite-ginger-poc/WalletWasabi.Documentation/Guides/TrezorSuiteGingerCoinJoinPoc.md).

## Tester safety

This changes an internal, unsupported Trezor Suite setting. Test only with an empty or low-value fresh account and never with funds you cannot afford to lose. Do not post seeds, PINs, passphrases, xpubs, addresses, transaction IDs, balances, complete logs, or screenshots containing wallet data.

Trezor Suite must be fully closed before Configure, Repair, or Restore. The temporary debugging interface binds to `127.0.0.1` on a random available port and is closed after the operation.

## Quick test procedure

### 1. Check out and run

```shell
gh pr checkout 196
dotnet restore --locked-mode
dotnet build WalletWasabi.Fluent.Desktop/WalletWasabi.Fluent.Desktop.csproj --configuration Debug
dotnet run --project WalletWasabi.Fluent.Desktop/WalletWasabi.Fluent.Desktop.csproj --configuration Debug
```

### 2. Configure

1. Fully close Trezor Suite.
2. Open **Ginger > Settings > Trezor**.
3. Confirm Suite is `Installed`, its version is plausible, the backend is `Online`, configuration is `Not configured`, and last verified is `Never`.
4. Click **Configure and open Trezor Suite**.
5. A temporary Suite/DevTools window may flash. Ginger should close it and open Suite normally.
6. Return to Ginger and press **Refresh** if needed.
7. Success requires both `Configured for Ginger` and a **Last verified** timestamp. `Installed` and `Online` alone are not success.

### 3. Check CoinJoin availability

1. Connect a Trezor and open a Bitcoin account in Suite.
2. Record whether CoinJoin controls appear. If they do not, stop and report the Suite version.
3. If controls appear, use only a fresh, low-value test account.
4. Check whether round information loads without an affiliation error.
5. Proceed further only if you accept the mainnet PoC risk, and verify every hardware prompt. Report the furthest protocol phase reached without publishing wallet data.

### 4. Restore

1. Fully close Suite.
2. In **Settings > Trezor**, click **Restore original configuration**.
3. Confirm Suite opens normally, Ginger no longer reports the override as configured, and the Restore action disappears.

Please follow the full guide for intentional failure testing, troubleshooting, limitations, and the report template.

## Current validation

- `dotnet build WalletWasabi.Fluent.Desktop/WalletWasabi.Fluent.Desktop.csproj --no-restore --configuration Debug -m:1`: passed with 0 errors and 0 warnings.
- Focused `TrezorSuiteIntegrationTests`: 4 passed.
- Generated read/apply/restore JavaScript expressions: syntax-checked with Node.
- Ginger coordinator software-version and WabiSabi status endpoints: HTTP 200 during development.
- Windows 11 / Trezor Suite 26.8.2: executable auto-detected; temporary debug launch, IndexedDB write/read verification, clean temporary shutdown, and normal relaunch observed.
- No complete Trezor hardware CoinJoin round has been claimed or tested yet.

## Review notes / limitations

- This depends on internal Suite database/store/key names and may break with any Suite release.
- Ginger records the last verified write; it does not continuously monitor Suite.
- An already-running Suite is intentionally not terminated by Ginger.
- Cross-platform discovery and process handling compile, but runtime coverage so far is Windows only.
- The PoC stores the original debug JSON in Ginger's data directory so it can restore it later.
- `affiliationId` must be `null`; Ginger does not implement Trezor's former Wasabi affiliation endpoint.
