### PR TITLE
Fix macOS CoinJoin stop crash

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Helpers/PowerSaving/BaseInhibitorTaskTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Helpers/PowerSaving/BaseInhibitorTaskTests.cs
@@ -17,10 +17,12 @@ public class BaseInhibitorTaskTests
 	[Fact]
 	public async Task CancelBehaviorAsync()
 	{
+		bool? killedEntireProcessTree = null;
+
 		using MockProcessAsync mockProcess = new(new ProcessStartInfo());
 		mockProcess.OnWaitForExitAsync = (cancellationToken) => Task.Delay(Timeout.Infinite, cancellationToken);
 		mockProcess.OnHasExited = () => false;
-		mockProcess.OnKill = b => { };
+		mockProcess.OnKill = entireProcessTree => killedEntireProcessTree = entireProcessTree;
 
 		TestInhibitorClass psTask = new(TimeSpan.FromSeconds(10), DefaultReason, mockProcess);
 
@@ -35,6 +37,9 @@ public class BaseInhibitorTaskTests
 
 		// Prolong after exit must fail.
 		Assert.False(psTask.Prolong(TimeSpan.FromSeconds(5)));
+
+		// Killing a process tree can signal the wallet process group on macOS.
+		Assert.False(killedEntireProcessTree);
 	}
 
 	public class TestInhibitorClass : BaseInhibitorTask

--- a/WalletWasabi.Tests/UnitTests/Helpers/PowerSaving/MacOsInhibitorTaskTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Helpers/PowerSaving/MacOsInhibitorTaskTests.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Diagnostics;
+using WalletWasabi.Helpers.PowerSaving;
+using Xunit;
+
+namespace WalletWasabi.Tests.UnitTests.Helpers.PowerSaving;
+
+public class MacOsInhibitorTaskTests
+{
+	[Fact]
+	public void CaffeinateWatchesWalletProcess()
+	{
+		ProcessStartInfo startInfo = MacOsInhibitorTask.CreateProcessStartInfo();
+
+		Assert.Equal("caffeinate", startInfo.FileName);
+		Assert.Equal($"-i -w {Environment.ProcessId}", startInfo.Arguments);
+		Assert.False(startInfo.UseShellExecute);
+	}
+}

--- a/WalletWasabi/Helpers/PowerSaving/BaseInhibitorTask.cs
+++ b/WalletWasabi/Helpers/PowerSaving/BaseInhibitorTask.cs
@@ -70,7 +70,7 @@ public class BaseInhibitorTask : IPowerSavingInhibitorTask
 				// Process cannot stop on its own so we know it is actually running.
 				try
 				{
-					Process.Kill(entireProcessTree: true);
+					Process.Kill();
 					Logger.LogTrace("Inhibit task was killed.");
 				}
 				catch (Exception ex)

--- a/WalletWasabi/Helpers/PowerSaving/MacOsInhibitorTask.cs
+++ b/WalletWasabi/Helpers/PowerSaving/MacOsInhibitorTask.cs
@@ -16,30 +16,19 @@ public class MacOsInhibitorTask : BaseInhibitorTask
 
 	public static MacOsInhibitorTask Create(TimeSpan basePeriod, string reason)
 	{
-		// The script is written with newlines but we need to pass the script to
-		// bash -c as a one-liner, so that's why we use the "ReplaceLineEndings" command.
-		//
-		// Note that this script requires dollar signs ($) and quotes (") to be escaped.
-		string innerCommand = $$"""
-			caffeinate -i &
-			caffeinatePid=$!;
-			trap \"kill -9 \$caffeinatePid\" 0 SIGINT SIGTERM;
-			while (ps -p {{Environment.ProcessId}} );
-			do
-				sleep 1;
-			done;
-			""".ReplaceLineEndings(replacementText: " ");
+		ProcessStartInfo startInfo = CreateProcessStartInfo();
 
-		string command = $"/bin/bash";
-		string arguments = $"-c \"{innerCommand}\"";
-
-		Logger.LogTrace($"Command to invoke: {command} {arguments}");
-		ProcessStartInfo startInfo = GetProcessStartInfo(command, arguments);
+		Logger.LogTrace($"Command to invoke: {startInfo.FileName} {startInfo.Arguments}");
 
 		ProcessAsync process = new(startInfo);
 		process.Start();
 		MacOsInhibitorTask task = new(basePeriod, reason, process);
 
 		return task;
+	}
+
+	internal static ProcessStartInfo CreateProcessStartInfo()
+	{
+		return GetProcessStartInfo("caffeinate", $"-i -w {Environment.ProcessId}");
 	}
 }


### PR DESCRIPTION
## Summary

- Run macOS `caffeinate` directly with `-i -w <wallet PID>` instead of a background Bash watchdog.
- Stop only the inhibitor process, avoiding the process-group signal that can close the wallet when CoinJoin stops.
- Add regression coverage for both the command arguments and non-tree process termination.

Port of WalletWasabi/WalletWasabi#14926, which fixes WalletWasabi/WalletWasabi#14918.

## Testing

- `dotnet build WalletWasabi/WalletWasabi.csproj --no-restore -p:NuGetAudit=false -m:1`
- Dependent Backend, Fluent, and Packager project builds
- `dotnet test WalletWasabi.Tests/WalletWasabi.Tests.csproj --no-restore -p:NuGetAudit=false -p:BuildProjectReferences=false -m:1 --filter FullyQualifiedName~BaseInhibitorTaskTests|FullyQualifiedName~MacOsInhibitorTaskTests` (2 passed)