### PR TITLE
Document reproducibility boundary for signed Windows releases

### DIFF
--- a/WalletWasabi.Documentation/ClientRelease/ReleaseNotesTemplate.md
+++ b/WalletWasabi.Documentation/ClientRelease/ReleaseNotesTemplate.md
@@ -28,7 +28,7 @@ For a detailed installation guide, including **signature verification**, see [th
 ## Advanced Guide
 If you want to build or update Wasabi from source code, check out [these easy instructions](https://docs.wasabiwallet.io/using-wasabi/BuildSource.html).
 
-Wasabi uses [reproducible builds](https://reproducible-builds.org/), which you can verify with [this guide](https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi.Documentation/Guides/DeterministicBuildGuide.md).
+Ginger uses [reproducible builds](https://reproducible-builds.org/), which you can verify with [this guide](https://github.com/GingerPrivacy/GingerWallet/blob/master/WalletWasabi.Documentation/Guides/DeterministicBuildGuide.md).
 
 ## Requirements
 - Windows 10 1607+

--- a/WalletWasabi.Documentation/Guides/DeterministicBuildGuide.md
+++ b/WalletWasabi.Documentation/Guides/DeterministicBuildGuide.md
@@ -1,110 +1,142 @@
-# Guide for deterministic builds
+# Guide for reproducible builds
 
-The term *deterministic builds* is [defined](https://reproducible-builds.org/) as follows:
+[Reproducible builds](https://reproducible-builds.org/) provide an independently verifiable path from source code to binary code. This guide explains how to rebuild Ginger Wallet and compare the result with an official release.
 
-> Reproducible [or deterministic] builds are a set of software development practices that create an independently-verifiable path from source to binary code.
+## Artifact scope
 
-This guide describes how to reproduce Wasabi's builds. If you get stuck with these instructions, take a look at [how to build Wasabi from source code](https://docs.wasabiwallet.io/using-wasabi/BuildSource.html).
+Ginger publishes both portable archives and signed installers. Their verification boundaries are different:
 
-**Warning:** Reproducible builds were introduced in [1.1.3 release](https://github.com/zkSNACKs/WalletWasabi/releases/tag/v1.1.3), you cannot use these instructions for older versions!
+| Artifact | Verification boundary |
+| --- | --- |
+| `Ginger-<version>-win-x64.zip` | The extracted application payload is reproducible and can be compared file by file. |
+| Linux and macOS portable ZIPs | The extracted application payload can be compared file by file. |
+| Windows MSI | The MSI and its two Ginger executables contain Authenticode signatures and timestamps. Verify the signatures and compare the application payload as described below; do not expect flat-file SHA-256 equality. |
+| macOS DMG | Apple signing and notarization modify the application bundle. The signed DMG is not expected to be bit-for-bit identical to an unsigned local build. |
 
-## 1. Assert correct environment
+Archive metadata can differ even when every extracted file matches, so verification compares the extracted payload rather than the ZIP container bytes.
 
-In order to reproduce Wasabi's builds, you need [git](https://git-scm.com/) package, Windows 10+, and the version of [.NET SDK](https://dotnet.microsoft.com/download) that was used by the Wasabi team to produce the release.
+## 1. Match the official build environment
 
-Which version of .NET SDK to use? There is the `BUILDINFO.json` file inside the installation folder: `C:\Program Files\WasabiWallet\`, and the `NetSdkVersion` field will tell you the right SDK version. If you have multiple .NET SDK versions installed on your system, make sure to specify the exact same version in `global.json` before building Wasabi Wallet. `global.json` is in the root of the repository folder.
+Install [Git](https://git-scm.com/) and the exact [.NET SDK](https://dotnet.microsoft.com/download) recorded in the release's `BUILDINFO.json`. The file is included in every portable archive and installed application directory. Its `NetSdkVersion` and `NetRuntimeVersion` fields identify the toolchain used for the official build.
 
-Example of `global.json` that is set to strictly use a specific version:
+The official Windows payload is produced on Windows. Use Windows 10 or later when verifying Windows artifacts because platform-dependent files can differ when the same target is published from another operating system.
 
-```json
-{
-  "sdk": {
-    "version": "7.0.100",
-    "allowPrerelease": false,
-    "rollForward": "disable"
+If more than one SDK is installed, update the repository's `global.json` to select the exact `NetSdkVersion` and set `rollForward` to `disable` before building.
+
+## 2. Build the release tag
+
+Every release has a corresponding tag in the [Ginger Wallet repository](https://github.com/GingerPrivacy/GingerWallet/releases). Replace `<version>` below with a release version such as `2.0.26`.
+
+```powershell
+git clone --depth 1 --branch "v<version>" https://github.com/GingerPrivacy/GingerWallet.git
+Set-Location GingerWallet\WalletWasabi.Packager
+dotnet nuget locals all --clear
+dotnet restore --locked-mode
+dotnet run -- --onlybinaries
+$repoRoot = Resolve-Path ..
+```
+
+The output directories are under `WalletWasabi.Fluent.Desktop\bin\dist`:
+
+```text
+win-x64
+linux-x64
+osx-x64
+osx-arm64
+```
+
+`--onlybinaries` stops before installer creation and code signing. These directories are the unsigned reference payloads.
+
+## 3. Compare portable archives
+
+Download the portable archive for the same version and target from [GitHub Releases](https://github.com/GingerPrivacy/GingerWallet/releases). For example, compare the Windows ZIP in PowerShell:
+
+```powershell
+Expand-Archive "Ginger-<version>-win-x64.zip" -DestinationPath official-win-x64
+$builtRoot = Join-Path $repoRoot "WalletWasabi.Fluent.Desktop\bin\dist\win-x64"
+git diff --no-index --exit-code `
+  $builtRoot `
+  "official-win-x64"
+```
+
+Exit code `0` and no reported differences mean that every extracted file matches. Use the equivalent target directory when checking a Linux or macOS portable ZIP.
+
+## 4. Verify the signed Windows MSI
+
+The release process creates the portable ZIP first, signs `wassabee.exe` and `wassabeed.exe`, builds the MSI from that signed directory, and finally signs the MSI itself. Authenticode embeds a certificate and an RFC 3161 timestamp in each signed file, so independently built unsigned files cannot have the same flat-file SHA-256 value.
+
+First verify the MSI and extract its payload without installing it:
+
+```powershell
+$msi = Resolve-Path "Ginger-<version>.msi"
+$signature = Get-AuthenticodeSignature $msi
+if ($signature.Status -ne "Valid") {
+  throw "Invalid MSI Authenticode signature: $($signature.StatusMessage)"
+}
+
+$extractRoot = Join-Path $PWD "official-msi"
+New-Item -ItemType Directory -Force $extractRoot | Out-Null
+Start-Process msiexec.exe -Wait -ArgumentList @(
+  "/a", "`"$msi`"", "/qn", "TARGETDIR=`"$extractRoot`""
+)
+```
+
+Compare the extracted `GingerWallet` directory with the locally built `win-x64` directory. All files except the two Ginger executables must match exactly. Verify each executable's signature and compare its Authenticode image hash:
+
+```powershell
+$msiRoot = Resolve-Path "official-msi\GingerWallet"
+$signedFiles = [Collections.Generic.HashSet[string]]::new(
+  [string[]]@("wassabee.exe", "wassabeed.exe"),
+  [StringComparer]::OrdinalIgnoreCase
+)
+
+function Get-UnsignedPayloadManifest([string] $root) {
+  Get-ChildItem $root -Recurse -File | ForEach-Object {
+    $relativePath = [IO.Path]::GetRelativePath($root, $_.FullName)
+    if (-not $signedFiles.Contains($relativePath)) {
+      [pscustomobject]@{
+        RelativePath = $relativePath
+        SHA256 = (Get-FileHash $_.FullName -Algorithm SHA256).Hash
+      }
+    }
   }
 }
+
+$payloadDiff = Compare-Object `
+  (Get-UnsignedPayloadManifest $builtRoot) `
+  (Get-UnsignedPayloadManifest $msiRoot) `
+  -Property RelativePath, SHA256
+if ($payloadDiff) {
+  $payloadDiff | Format-Table
+  throw "Unsigned MSI payload files do not match the reproducible build."
+}
+
+foreach ($name in "wassabee.exe", "wassabeed.exe") {
+  $built = Join-Path $builtRoot $name
+  $signed = Join-Path $msiRoot $name
+
+  $signature = Get-AuthenticodeSignature $signed
+  if ($signature.Status -ne "Valid") {
+    throw "Invalid signature on ${name}: $($signature.StatusMessage)"
+  }
+
+  $builtHash = (Get-AppLockerFileInformation -Path $built).Hash
+  $signedHash = (Get-AppLockerFileInformation -Path $signed).Hash
+  if ($builtHash -ne $signedHash) {
+    throw "Authenticode image hash mismatch for ${name}."
+  }
+}
+
+Write-Output "MSI payload matches the reproducible build modulo valid Authenticode signatures."
 ```
 
-## 2. Reproduce builds
+Windows calculates the Authenticode image hash without the PE checksum, certificate-table entry, or certificate table. Consequently, the hash remains stable when a signature or timestamp is added or removed while still covering the executable image. See Microsoft's documentation on [Authenticode/PE image hashes](https://learn.microsoft.com/windows/security/application-security/application-control/app-control-for-business/design/select-types-of-rules-to-create#more-information-about-hashes).
 
-You can see the list of Wasabi releases here: https://github.com/zkSNACKs/WalletWasabi/releases. Please note that each release has a git tag assigned, which is useful in the following instructions:
+This procedure verifies that the signed executables contain the reproducible application image. It does **not** make the MSI itself bit-for-bit reproducible. In addition to signatures and timestamps, the WiX project generates installer identifiers while building the package.
 
-```sh
-# The following command downloads only a single git branch. However, you can clone the whole repository, which is bigger.
-git clone --depth 1 --branch <git-branch-or-tag> https://github.com/zkSNACKs/WalletWasabi.git # where `<git-branch-or-tag>` may be, for example, `v1.1.11.1`.
-cd WalletWasabi/WalletWasabi.Packager
-dotnet nuget locals all --clear
-dotnet restore
-dotnet build
-dotnet run -- --onlybinaries
-```
+## 5. Signed macOS artifacts
 
-The previous commands produce Wasabi's binaries for Windows, macOS and Linux. Also, for your convenience, a new file explorer window will navigate you to the binaries location - i.e. `WalletWasabi\\WalletWasabi.Fluent.Desktop\\bin\\dist`.
-
-![](https://i.imgur.com/8XAQzz4.png)
-
-## 3. Verify builds
-
-Now, we will attempt to verify the binaries you have just compiled with the officially distributed binaries on https://wasabiwallet.io website. Please download those packages from the website, you should see the following files in your File Explorer:
-
-![](https://i.imgur.com/aI9Kx0c.png)
-
-### Windows
-
-* Install Wasabi using `Wasabi-<version>.msi` file. It will install to `C:\Program Files\WasabiWallet` directory.
-* Start `cmd` or Powershell and navigate to the `dist` directory.
-* Execute the following command:
-  ```sh
-  git diff --no-index "win7-x64" "C:\Program Files\WasabiWallet"
-  ```
-* Make sure that there is **NO** difference reported by the command.
-
-### Linux & macOS
-
-You can use the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/) to verify all the packages in one go. At the time of writing this guide we provide `.tar.gz` and `.deb` packages for Linux and `.dmg` package for macOS.  
-Install the `.deb` package and extract the `tar.gz` and `.dmg` packages, then compare them with your build.
-
-After [installing WSL](https://docs.microsoft.com/en-us/windows/wsl/install-win10), just type `wsl` in File Explorer where your downloaded and built packages are located.
-
-![](https://i.imgur.com/yRUjxvG.png)
-
-#### .deb
-
-```sh
-sudo dpkg -i Wasabi-1.1.6.deb
-git diff --no-index linux-x64/ /usr/local/bin/wasabiwallet/
-```
-
-#### .tar.gz
-
-```sh
-tar -pxzf Wasabi-1.1.6.tar.gz
-git diff --no-index linux-x64/ Wasabi-1.1.6
-```
-
-*There could be warnings regarding SOS_README.md that it differs in line endings. That is a text file and it has no effect on the running software.*
-
-#### .dmg
-
-According to Apple documentation, the signature that is used to ensure the integrity of the software is added into the binary itself - so it will manipulate the content of the files.
-
-> If the code is universal, the object code for each slice (architecture) is signed separately. This signature is stored within the binary file itself.
-
-[Source](https://developer.apple.com/library/archive/documentation/Security/Conceptual/CodeSigningGuide/AboutCS/AboutCS.html#//apple_ref/doc/uid/TP40005929-CH3-SW3)
-
-According to this, it is impossible to have both deterministic build and code signature on macOS. macOS Gatekeeper won't let you run software without it. Thus, Wasabi only applies code signature, but no deterministic build for macOS. 
-
-There is an issue [here](https://github.com/zkSNACKs/WalletWasabi/issues/4110) for further discussion. 
-
-With the following method you can check the differences by yourself:
-
-You will need to install `7z` (or something else) to extract the `.dmg`. You can do that using `sudo apt install p7zip-full` command.
-
-```sh
-7z x Wasabi-1.1.6.dmg -oWasabiOsx
-git diff --no-index osx-x64/ WasabiOsx/Wasabi\ Wallet.App/Contents/MacOS/
-```
+Apple stores code signatures inside Mach-O binaries and the application bundle. Gatekeeper requires distributed applications to be signed and notarized, so the official DMG is expected to differ from an unsigned local build. Use the portable macOS ZIP for reproducible payload comparison, and use Apple's `codesign` and `spctl` tools to validate the distributed signed application.
 
 ## Bitcoin Core bundled binaries
 

--- a/WalletWasabi.Packager/ArgsProcessor.cs
+++ b/WalletWasabi.Packager/ArgsProcessor.cs
@@ -14,8 +14,8 @@ public class ArgsProcessor
 
 	public string[] Args { get; }
 
-	/// <summary>Builds Wasabi Wallet binaries for supported platforms to be compared then with the official binaries, and terminates.</summary>
-	/// <seealso href="https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi.Documentation/Guides/DeterministicBuildGuide.md"/>
+	/// <summary>Builds Ginger Wallet binaries for supported platforms to be compared with the official binaries, and terminates.</summary>
+	/// <seealso href="https://github.com/GingerPrivacy/GingerWallet/blob/master/WalletWasabi.Documentation/Guides/DeterministicBuildGuide.md"/>
 	public bool IsOnlyBinariesMode() => IsOneOf("onlybinaries") || Args is null || Args.Length == 0;
 
 	public bool IsContinuousDeliveryMode() => IsOneOf("cdelivery");


### PR DESCRIPTION
## Summary

- replace stale Wasabi-era build instructions with Ginger release-tag and artifact-specific guidance
- scope reproducibility to extracted portable payloads and explain why signed MSI bytes differ
- add a mechanical MSI verification procedure that checks exact hashes for all unsigned payload files, validates the MSI and inner executable signatures, and compares Authenticode image hashes for the two signed Ginger executables
- update the packager and release-note links to the Ginger guide

## Context

WalletScrutiny reproduced the v2.0.25 Windows portable ZIP, not the MSI. Since v2.0.26, the release process signs `wassabee.exe` and `wassabeed.exe` before WiX packages them, then signs the MSI. The previous guide still required an installed MSI to have no byte differences from an unsigned `--onlybinaries` build, which is no longer possible.

## Validation

- `git diff --check`
- executed the documented comparison against the official v2.0.26 Windows ZIP and MSI
- all non-Ginger-executable payload files matched byte-for-byte
- the MSI and both embedded Ginger executables had valid Authenticode signatures
- unsigned and signed copies produced matching Authenticode SHA-256 image hashes for both Ginger executables